### PR TITLE
Fix error message on activation

### DIFF
--- a/includes/activator.php
+++ b/includes/activator.php
@@ -18,7 +18,7 @@ function sendsmaily_install() {
 
 	// Create database table - settings.
 	$table_name = esc_sql( $wpdb->prefix . 'sendsmaily_config' );
-	$query = "SHOW TABLES LIKE `$table_name`";
+	$query = "SHOW TABLES LIKE '$table_name'";
 	if ( ! $wpdb->get_var( $query ) ) {
 		$sql = trim(
 			preg_replace(
@@ -39,7 +39,7 @@ function sendsmaily_install() {
 
 	// Create database table - autoresponders.
 	$table_name = esc_sql( $wpdb->prefix . 'sendsmaily_autoresp' );
-	$query = "SHOW TABLES LIKE `$table_name`";
+	$query = "SHOW TABLES LIKE '$table_name'";
 	if ( ! $wpdb->get_var( $query ) ) {
 		$sql = trim(
 			preg_replace(

--- a/includes/activator.php
+++ b/includes/activator.php
@@ -17,41 +17,34 @@ function sendsmaily_install() {
 	$charset_collate = $wpdb->get_charset_collate();
 
 	// Create database table - settings.
-	$table_name = esc_sql( $wpdb->prefix . 'sendsmaily_config' );
-	$query = "SHOW TABLES LIKE '$table_name'";
-	if ( ! $wpdb->get_var( $query ) ) {
-		$sql = trim(
-			preg_replace(
-				'/\s\s+/',
-				' ',
-				"CREATE TABLE `$table_name` (
-				`key` VARCHAR(128) NOT NULL,
-				`domain` VARCHAR(255) NOT NULL,
-				`autoresponder` INT(16) NOT NULL,
-				`form` TEXT NOT NULL,
-				`is_advanced` TINYINT(1) NOT NULL,
-				PRIMARY KEY(`key`)
-				) $charset_collate;"
-			)
-		);
-		$wpdb->query( $sql );
+	$table_name            = esc_sql( $wpdb->prefix . 'sendsmaily_config' );
+	$settings_table_exists = $wpdb->get_var(
+		$wpdb->prepare(
+			'SHOW TABLES LIKE %s',
+			$table_name
+		)
+	);
+	if ( ! $settings_table_exists ) {
+		$sql = "CREATE TABLE $table_name ( " .
+				'`key` VARCHAR(128) NOT NULL, ' .
+				'domain VARCHAR(255) NOT NULL, ' .
+				'autoresponder INT(16) NOT NULL, ' .
+				'form TEXT NOT NULL, ' .
+				'is_advanced TINYINT(1) NOT NULL, ' .
+				'PRIMARY KEY(`key`) ' .
+				") $charset_collate;";
+		$wpdb->query( $sql ); // Can't use prepare - makes quotes around values.
+		// TODO: Switch to dbDelta().
+		// There is a problem with reserved "key" column name and can't use backticks in dbDelta function.
+		// Should change column name to something else.
 	}
 
 	// Create database table - autoresponders.
 	$table_name = esc_sql( $wpdb->prefix . 'sendsmaily_autoresp' );
-	$query = "SHOW TABLES LIKE '$table_name'";
-	if ( ! $wpdb->get_var( $query ) ) {
-		$sql = trim(
-			preg_replace(
-				'/\s\s+/',
-				' ',
-				"CREATE TABLE `$table_name` (
-				`id` INT(16) NOT NULL,
-				`title` VARCHAR(255) NOT NULL,
-				PRIMARY KEY (`id`)
-				) $charset_collate;"
-			)
-		);
-		$wpdb->query( $sql );
-	}
+	$sql        = "CREATE TABLE $table_name (
+				id int(16) NOT NULL,
+				title varchar(255) NOT NULL,
+				PRIMARY KEY  (id)
+			) $charset_collate;";
+	dbDelta( $sql );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Sendsmaily ===
 Tags: widget, plugin, sidebar, api, mail, email, marketing, sendsmaily
-Tested up to: 5.1
-Stable tag: 1.2.2
+Tested up to: 5.2.2
+Stable tag: 1.2.3
 License: GPLv2 or later
 
 Sendsmaily newsletter subscription plugin for WordPress
@@ -20,6 +20,9 @@ Sendsmaily newsletter subscription plugin for WordPress.
 * Using advanced tab in smaily settings will render advanced form.
 
 == Changelog ==
+
+= 1.2.3 =
+* Bugfix: Removes error message on plugin activation.
 
 = 1.2.2 =
 * Maintenance: Unifies table creation on installation.

--- a/sendsmaily.php
+++ b/sendsmaily.php
@@ -9,7 +9,7 @@
  * Plugin URI:        https://github.com/sendsmaily/sendsmaily-wordpress-plugin
  * Text Domain:       wp_sendsmaily
  * Description:       Smaily newsletter subscription form.
- * Version:           1.2.2
+ * Version:           1.2.3
  * Author:            Sendsmaily LLC
  * Author URI:        https://smaily.com
  * License:           GPL-2.0+
@@ -19,7 +19,7 @@
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'SS_PLUGIN_VERSION', '1.2.2' );
+define( 'SS_PLUGIN_VERSION', '1.2.3' );
 
 if (!defined('BP')) define( 'BP', dirname( __FILE__ ) );
 


### PR DESCRIPTION
Fixes #14 

No more error messages when activating plugin.
`show tables like` query returned error and with that a `null` value. That caused creating tables even though tables were already created.

Ideal solution would be that if we switched to `dbDelta()` functionality but that means we no loger can use `key` as a column name. This workload is much bigger. This was the simplest solution I found.