### PR TITLE
Deprecate 1.x version and implement uninstall hook

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Sendsmaily ===
 Tags: widget, plugin, sidebar, api, mail, email, marketing, sendsmaily
 Tested up to: 5.2.2
-Stable tag: 1.2.3
+Stable tag: 1.2.4
 License: GPLv2 or later
 
 Sendsmaily newsletter subscription plugin for WordPress
@@ -20,6 +20,9 @@ Sendsmaily newsletter subscription plugin for WordPress.
 * Using advanced tab in smaily settings will render advanced form.
 
 == Changelog ==
+
+= 1.2.4 =
+* Added support for an uninstall hook via uninstall.php, because two tables were being leftover after uninstall.
 
 = 1.2.3 =
 * Bugfix: Removes error message on plugin activation.

--- a/sendsmaily.php
+++ b/sendsmaily.php
@@ -254,7 +254,7 @@ add_action( 'admin_post_smly', 'smaily_nojs_subscribe_callback' );
 // Place a deprecation notice into the plugin's metainfo row as the first element.
 function smaily_add_deprecation_notice($meta, $file) {
 	if ($file === plugin_basename( __FILE__ )) {
-		array_unshift($meta, '<b>This version is deprecated, please update</b>');
+		array_unshift($meta, '<b>This plugin is deprecated, please install <a href=https://wordpress.org/plugins/smaily-for-wp/>Smaily for Wordpress</a></b>');
 	}
 	return $meta;
 }

--- a/sendsmaily.php
+++ b/sendsmaily.php
@@ -254,8 +254,8 @@ add_action( 'admin_post_smly', 'smaily_nojs_subscribe_callback' );
 $path = plugin_basename( __FILE__ );
 // display plugin upgrade notification
 add_action("after_plugin_row_{$path}", function( $plugin_file, $plugin_data, $status ) {
-	echo '<tr class="active"><td>&nbsp;</td><td colspan="2">
-        <p style="background-color: #d54e21; padding: 5px; color: #f9f9f9">
+	echo '<tr class="active"><td colspan="3">
+        <p style="background-color: #d54e21; padding: 10px; color: #f9f9f9">
 		<strong>This version is no longer being developed. Please update.</strong>
         </td></tr>';
 }, 10, 3 );

--- a/sendsmaily.php
+++ b/sendsmaily.php
@@ -9,7 +9,7 @@
  * Plugin URI:        https://github.com/sendsmaily/sendsmaily-wordpress-plugin
  * Text Domain:       wp_sendsmaily
  * Description:       Smaily newsletter subscription form.
- * Version:           1.2.3
+ * Version:           1.2.4
  * Author:            Sendsmaily LLC
  * Author URI:        https://smaily.com
  * License:           GPL-2.0+
@@ -19,7 +19,7 @@
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'SS_PLUGIN_VERSION', '1.2.3' );
+define( 'SS_PLUGIN_VERSION', '1.2.4' );
 
 if (!defined('BP')) define( 'BP', dirname( __FILE__ ) );
 
@@ -250,3 +250,10 @@ function smaily_nojs_subscribe_callback() {
 }
 add_action( 'admin_post_nopriv_smly', 'smaily_nojs_subscribe_callback' );
 add_action( 'admin_post_smly', 'smaily_nojs_subscribe_callback' );
+
+function showUpgradeNotification($currentPluginMetadata, $newPluginMetadata){
+	echo '<p style="background-color: #d54e21; padding: 10px; color: #f9f9f9; margin-top: 10px">
+		<strong>This version is no longer being developed. Please update.</strong> ';
+}
+// add plugin upgrade notification
+add_action('in_plugin_update_message-sendsmaily-wordpress-plugin/sendsmaily.php', 'showUpgradeNotification', 10, 2);

--- a/sendsmaily.php
+++ b/sendsmaily.php
@@ -251,11 +251,11 @@ function smaily_nojs_subscribe_callback() {
 add_action( 'admin_post_nopriv_smly', 'smaily_nojs_subscribe_callback' );
 add_action( 'admin_post_smly', 'smaily_nojs_subscribe_callback' );
 
-$path = plugin_basename( __FILE__ );
-// display plugin upgrade notification
-add_action("after_plugin_row_{$path}", function( $plugin_file, $plugin_data, $status ) {
-	echo '<tr class="active"><td colspan="3">
-        <p style="background-color: #d54e21; padding: 10px; color: #f9f9f9">
-		<strong>This version is no longer being developed. Please update.</strong>
-        </td></tr>';
-}, 10, 3 );
+// Place a deprecation notice into the plugin's metainfo row as the first element.
+function smaily_add_deprecation_notice($meta, $file) {
+	if ($file === plugin_basename( __FILE__ )) {
+		array_unshift($meta, '<b>This version is deprecated, please update</b>');
+	}
+	return $meta;
+}
+add_filter('plugin_row_meta', 'smaily_add_deprecation_notice', 10, 4);

--- a/sendsmaily.php
+++ b/sendsmaily.php
@@ -251,9 +251,11 @@ function smaily_nojs_subscribe_callback() {
 add_action( 'admin_post_nopriv_smly', 'smaily_nojs_subscribe_callback' );
 add_action( 'admin_post_smly', 'smaily_nojs_subscribe_callback' );
 
-function showUpgradeNotification($currentPluginMetadata, $newPluginMetadata){
-	echo '<p style="background-color: #d54e21; padding: 10px; color: #f9f9f9; margin-top: 10px">
-		<strong>This version is no longer being developed. Please update.</strong> ';
-}
-// add plugin upgrade notification
-add_action('in_plugin_update_message-sendsmaily-wordpress-plugin/sendsmaily.php', 'showUpgradeNotification', 10, 2);
+$path = plugin_basename( __FILE__ );
+// display plugin upgrade notification
+add_action("after_plugin_row_{$path}", function( $plugin_file, $plugin_data, $status ) {
+	echo '<tr class="active"><td>&nbsp;</td><td colspan="2">
+        <p style="background-color: #d54e21; padding: 5px; color: #f9f9f9">
+		<strong>This version is no longer being developed. Please update.</strong>
+        </td></tr>';
+}, 10, 3 );

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,3 +8,5 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
 global $wpdb;
 $wpdb->query("DROP TABLE IF EXISTS {$wpdb->prefix}sendsmaily_autoresp");
 $wpdb->query("DROP TABLE IF EXISTS {$wpdb->prefix}sendsmaily_config");
+
+delete_option("widget_sendsmaily_subscription_widget");

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,10 @@
+<?php
+
+// if uninstall.php is not called by WordPress, die
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+    die;
+}
+
+global $wpdb;
+$wpdb->query("DROP TABLE IF EXISTS {$wpdb->prefix}sendsmaily_autoresp");
+$wpdb->query("DROP TABLE IF EXISTS {$wpdb->prefix}sendsmaily_config");


### PR DESCRIPTION
Because two smaily tables are leftover after uninstalling. Uninstall.php will delete them.
Also added a big deprecation notice 'This version is no longer being developed. Please update.'