### PR TITLE
Seperate credentials from request class

### DIFF
--- a/action.php
+++ b/action.php
@@ -74,15 +74,10 @@ function smaily_admin_save() {
 			}
 
 			// Validate credentials with get request.
-			$rqst = new Smaily_Plugin_Request(
-				'https://' . $params['subdomain'] . '.sendsmaily.net/api/workflows.php?trigger_type=form_submitted',
-				array(
-					'username' => $params['username'],
-					'password' => $params['password'],
-				)
-			);
-			// Response.
-			$rqst = $rqst->get();
+			$rqst = (new Smaily_Plugin_Request())
+				->auth($params['username'], $params['password'])
+				->setUrl('https://' . $params['subdomain'] . '.sendsmaily.net/api/workflows.php?trigger_type=form_submitted')
+				->get();
 
 			// Error handilng.
 			$code = isset( $rqst['code'] ) ? $rqst['code'] : '';
@@ -199,14 +194,10 @@ function smaily_admin_save() {
 			// Credentials.
 			$api_credentials = explode( ':', $data->api_credentials );
 			// Get autoresponders.
-			$request = new Smaily_Plugin_Request(
-				'https://' . $data->domain . '.sendsmaily.net/api/workflows.php?trigger_type=form_submitted',
-				array(
-					'username' => $api_credentials[0],
-					'password' => $api_credentials[1],
-				)
-			);
-			$result        = $request->get();
+			$result = (new Smaily_Plugin_Request())
+				->setUrl('https://' . $data->domain . '.sendsmaily.net/api/workflows.php?trigger_type=form_submitted')
+				->auth($api_credentials[0], $api_credentials[1])
+				->get();
 			$autoresponders = $result['body'];
 
 			// Handle errors.

--- a/code/Request.php
+++ b/code/Request.php
@@ -1,37 +1,29 @@
 <?php
 
 class Smaily_Plugin_Request {
-	/**
-	 * Remote request url.
-	 *
-	 * @var string
-	 */
-	protected $_url = '';
 
-	/**
-	 * Remote request data.
-	 *
-	 * @var array
-	 */
+	protected $_url = NULL;
+
 	protected $_data = array();
 
-	/**
-	 * Constructor (set request variables).
-	 *
-	 * @param string $url Url.
-	 * @param array  $data Data.
-	 * @return void|bool
-	 */
-	public function __construct( $url, $data = null ) {
-		if ( ! is_string( $url ) || empty( $url ) ) {
-			return false;
-		}
-		$this->_url = $url;
+	private $_username = NULL;
 
-		// Set request data.
-		if ( is_array( $data ) && ! empty( $data ) ) {
-			$this->_data = $data;
-		}
+	private $_password = NULL;
+
+	public function auth($username, $password) {
+		$this->_username = $username;
+		$this->_password = $password;
+		return $this;
+	}
+
+	public function setUrl($url) {
+		$this->_url = $url;
+		return $this;
+	}
+
+	public function setData(array $data) {
+		$this->_data = $data;
+		return $this;
 	}
 
 	/**
@@ -41,7 +33,7 @@ class Smaily_Plugin_Request {
 		$response = [];
 		$auth     = array(
 			'headers' => array(
-				'Authorization' => 'Basic ' . base64_encode( $this->_data['username'] . ':' . $this->_data['password'] ),
+				'Authorization' => 'Basic ' . base64_encode( $this->_username . ':' . $this->_password ),
 			),
 		);
 		$api_call = wp_remote_get( $this->_url, $auth );

--- a/smaily-for-wp.php
+++ b/smaily-for-wp.php
@@ -148,8 +148,10 @@ function smaily_subscribe_callback() {
 
 	$array = array_merge( $array, $form_values );
 	require_once( SMLY4WP_PLUGIN_PATH . '/code/Request.php' );
-	$request = new Smaily_Plugin_Request( $server, $array );
-	$result  = $request->post();
+	$result = (new Smaily_Plugin_Request())
+		->setUrl($server)
+		->setData($array)
+		->post();
 
 	if ( empty( $result ) ) {
 		echo __( 'Something went wrong', 'wp_smaily' );
@@ -249,8 +251,10 @@ function smaily_nojs_subscribe_callback() {
 
 	$array = array_merge( $array, $form_values );
 	require_once( SMLY4WP_PLUGIN_PATH . '/code/Request.php' );
-	$request = new Smaily_Plugin_Request( $server, $array );
-	$result  = $request->post();
+	$result  = (new Smaily_Plugin_Request())
+		->setUrl($server)
+		->setData($array)
+		->post();
 
 	if ( empty( $result ) ) {
 		$redirect_url = add_query_arg( 'smaily_form_error',


### PR DESCRIPTION
This allows reusing the $request instance while keeping the API credentials separate from other data