### PR TITLE
Use success response

### DIFF
--- a/html/form/advanced.php
+++ b/html/form/advanced.php
@@ -6,7 +6,7 @@ $form = $this->form;
 <?php else : ?>
 <form id="smly" class="container" action="https://<?php echo $this->domain; ?>.sendsmaily.net/api/opt-in/" method="post">
 	<p class="error" style="padding:15px;background-color:#f2dede;margin:0 0 10px;display:<?php echo $this->form_has_response ? 'block' : 'none'; ?>"><?php echo esc_html( $this->response_message ); ?></p>
-	<p class="success" style="padding:15px;background-color:#dff0d8;margin:0 0 10px;display:none"><?php echo esc_html__( 'Thank you for subscribing to our newsletter.', 'wp_smaily' ); ?></p>
+	<p class="success" style="padding:15px;background-color:#dff0d8;margin:0 0 10px;display:<?php echo $this->form_is_successful ? 'block' : 'none'; ?>"><?php echo esc_html__( 'Thank you for subscribing to our newsletter.', 'wp_smaily' ); ?></p>
 	<input type="hidden" name="lang" value="<?php echo ( defined( 'ICL_LANGUAGE_CODE' ) ) ? ICL_LANGUAGE_CODE : ''; ?>" />
 	<input type="hidden" name="success_url" value="<?php echo $this->success_url ? $this->success_url : get_site_url(); ?>" />
 	<input type="hidden" name="failure_url" value="<?php echo $this->failure_url ? $this->failure_url : get_site_url(); ?>" />

--- a/html/form/basic.php
+++ b/html/form/basic.php
@@ -1,6 +1,6 @@
 <form id="smly" class="container" action="https://<?php echo $this->domain; ?>.sendsmaily.net/api/opt-in/" method="post">
 	<p class="error" style="padding:15px;background-color:#f2dede;margin:0 0 10px;display:<?php echo $this->form_has_response ? 'block' : 'none'; ?>"><?php echo esc_html( $this->response_message ); ?></p>
-	<p class="success" style="padding:15px;background-color:#dff0d8;margin:0 0 10px;display:none"><?php echo esc_html__( 'Thank you for subscribing to our newsletter.', 'wp_smaily' ); ?></p>
+	<p class="success" style="padding:15px;background-color:#dff0d8;margin:0 0 10px;display:<?php echo $this->form_is_successful ? 'block' : 'none'; ?>"><?php echo esc_html__( 'Thank you for subscribing to our newsletter.', 'wp_smaily' ); ?></p>
 	<input type="hidden" name="lang" value="<?php echo ( defined( 'ICL_LANGUAGE_CODE' ) ) ? ICL_LANGUAGE_CODE : ''; ?>" />
 	<input type="hidden" name="success_url" value="<?php echo $this->success_url ? $this->success_url : get_site_url(); ?>" />
 	<input type="hidden" name="failure_url" value="<?php echo $this->failure_url ? $this->failure_url : get_site_url(); ?>" />

--- a/includes/subscribe-widget.php
+++ b/includes/subscribe-widget.php
@@ -53,17 +53,17 @@ class Smaily_Newsletter_Subscription_Widget extends WP_Widget {
 		$template->assign( $config );
 		// Display responses on Smaily subscription form.
 		$form_has_response = false;
+		$form_is_successful = false;
 		$response_message  = null;
 
 		if ( ! isset( $config['api_credentials'] ) || empty( $config['api_credentials'] ) ) {
 			$form_has_response = true;
 			$response_message  = __( 'Smaily credentials not validated. Subscription form will not work!', 'wp_smaily' );
+		} elseif ( isset( $_GET['code'] ) && (int) $_GET['code'] === 101 ) {
+			$form_is_successful = true;
 		} elseif ( isset( $_GET['code'] ) || ! empty( $_GET['code'] ) ) {
 			$form_has_response = true;
 			switch ( (int) $_GET['code'] ) {
-				case 101:
-					$response_message = __( 'You have been successfully subscribed.', 'wp_smaily' );
-					break;
 				case 201:
 					$response_message = __( 'Form was not submitted using POST method.', 'wp_smaily' );
 					break;
@@ -78,6 +78,7 @@ class Smaily_Newsletter_Subscription_Widget extends WP_Widget {
 		$template->assign( array(
 			'form_has_response' => $form_has_response,
 			'response_message'  => $response_message,
+			'form_is_successful' => $form_is_successful,
 		) );
 		// Render template.
 		echo $template->render();


### PR DESCRIPTION
There is a `<p class="success">` in the forms that showed responses to successful subscriptions. It's light green vs. light red.
I could also remove it and stick with `<p class="error">`. I would suggest to recolor it and rename it too then.