### PR TITLE
Add uninstall hook

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Sendsmaily ===
 Tags: widget, plugin, sidebar, api, mail, email, marketing, sendsmaily
 Tested up to: 5.2.2
-Stable tag: 1.2.3
+Stable tag: 1.2.4
 License: GPLv2 or later
 
 Sendsmaily newsletter subscription plugin for WordPress
@@ -20,6 +20,9 @@ Sendsmaily newsletter subscription plugin for WordPress.
 * Using advanced tab in smaily settings will render advanced form.
 
 == Changelog ==
+
+= 1.2.4 =
+* Remove plugin created tables after uninstall.
 
 = 1.2.3 =
 * Bugfix: Removes error message on plugin activation.

--- a/sendsmaily.php
+++ b/sendsmaily.php
@@ -9,7 +9,7 @@
  * Plugin URI:        https://github.com/sendsmaily/sendsmaily-wordpress-plugin
  * Text Domain:       wp_sendsmaily
  * Description:       Smaily newsletter subscription form.
- * Version:           1.2.3
+ * Version:           1.2.4
  * Author:            Sendsmaily LLC
  * Author URI:        https://smaily.com
  * License:           GPL-2.0+
@@ -19,7 +19,7 @@
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'SS_PLUGIN_VERSION', '1.2.3' );
+define( 'SS_PLUGIN_VERSION', '1.2.4' );
 
 if (!defined('BP')) define( 'BP', dirname( __FILE__ ) );
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,9 @@
+<?php
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	die;
+}
+
+global $wpdb;
+$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}sendsmaily_autoresp" );
+$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}sendsmaily_config" );


### PR DESCRIPTION
Need the uninstall feature to reset client DB and delete the plugin install table.

I have a feeling that the client has more than one row in `sendsmaily_config` table.

When you successfully enter credentials and validate them the same form is displayed.
![image](https://user-images.githubusercontent.com/22918359/78060632-890e6f00-7394-11ea-8b05-9e88543dd070.png)


Can not access their DB to confirm, but the form display logic is based on DB values.
https://github.com/sendsmaily/sendsmaily-wordpress-plugin/blob/c616bb555b7db1c95a2d917e5bc971fec9c6612a/html/admin/html/form.php#L13