### PR TITLE
Set SVN username and display help by command line argument

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -24,6 +24,18 @@ PLUGIN_SLUG="smaily-for-wp"
 # Wordpress.org SVN repository username
 SVN_USER="sendsmaily"
 
+# Set SVN username/Display help
+while getopts "u:h" option
+do
+    case $option in
+        u ) SVN_USER=${OPTARG}
+            ;;
+        h ) echo "Usage: $(basename "$0") [-u SVN Username] -- Github to WordPress.org RELEASER"
+            exit
+            ;;
+    esac
+done
+
 # ----- STOP EDITING HERE -----
 
 set -e

--- a/release.sh
+++ b/release.sh
@@ -21,17 +21,29 @@
 # The slug of your WordPress.org plugin
 PLUGIN_SLUG="smaily-for-wp"
 
+usage() {
+    echo "Usage: $(basename "$0") -u SVN Username [-h] -- Github to WordPress.org RELEASER"
+    }
+
 while getopts "u:h" option
 do
     case $option in
         # Set Wordpress.org SVN repository username
         u ) SVN_USER=${OPTARG}
             ;;
-        h | * ) echo "Usage: $(basename "$0") -u SVN Username [-h] -- Github to WordPress.org RELEASER"
+        h | * )
+            usage
             exit 1
             ;;
     esac
 done
+
+# If no command line argument was passed
+if [ $OPTIND -eq 1 ];
+then
+    usage
+    exit 1
+fi
 
 # ----- STOP EDITING HERE -----
 

--- a/release.sh
+++ b/release.sh
@@ -30,7 +30,7 @@ do
     case $option in
         u ) SVN_USER=${OPTARG}
             ;;
-        h ) echo "Usage: $(basename "$0") [-u SVN Username] -- Github to WordPress.org RELEASER"
+        h ) echo "Usage: $(basename "$0") [-u SVN Username] [-h] -- Github to WordPress.org RELEASER"
             exit
             ;;
     esac

--- a/release.sh
+++ b/release.sh
@@ -21,17 +21,14 @@
 # The slug of your WordPress.org plugin
 PLUGIN_SLUG="smaily-for-wp"
 
-# Wordpress.org SVN repository username
-SVN_USER="sendsmaily"
-
-# Set SVN username/Display help
 while getopts "u:h" option
 do
     case $option in
+        # Set Wordpress.org SVN repository username
         u ) SVN_USER=${OPTARG}
             ;;
-        h ) echo "Usage: $(basename "$0") [-u SVN Username] [-h] -- Github to WordPress.org RELEASER"
-            exit
+        h | * ) echo "Usage: $(basename "$0") -u SVN Username [-h] -- Github to WordPress.org RELEASER"
+            exit 1
             ;;
     esac
 done


### PR DESCRIPTION
Provide SVN username by command line argument, useful if there are multiple contributors.
Since the releaser script now takes command line arguments, it might be useful to provide a simple help screen.

`-h` Display help
`-u SVN Username `Set SVN username

Closes #49
