### PR TITLE
Remove generic class from newsletter form

### DIFF
--- a/html/form/advanced.php
+++ b/html/form/advanced.php
@@ -4,7 +4,7 @@ $form = $this->form;
 <?php if ( ! empty( $form ) ) : ?>
 	<?php echo stripslashes( $form ); ?>
 <?php else : ?>
-<form id="smly" class="container" action="https://<?php echo $this->domain; ?>.sendsmaily.net/api/opt-in/" method="post">
+<form id="smly" action="https://<?php echo $this->domain; ?>.sendsmaily.net/api/opt-in/" method="post">
 	<p class="error" style="padding:15px;background-color:#f2dede;margin:0 0 10px;display:<?php echo $this->form_has_response ? 'block' : 'none'; ?>"><?php echo esc_html( $this->response_message ); ?></p>
 	<p class="success" style="padding:15px;background-color:#dff0d8;margin:0 0 10px;display:<?php echo $this->form_is_successful ? 'block' : 'none'; ?>"><?php echo esc_html__( 'Thank you for subscribing to our newsletter.', 'wp_smaily' ); ?></p>
 	<input type="hidden" name="lang" value="<?php echo ( defined( 'ICL_LANGUAGE_CODE' ) ) ? ICL_LANGUAGE_CODE : ''; ?>" />

--- a/html/form/basic.php
+++ b/html/form/basic.php
@@ -1,4 +1,4 @@
-<form id="smly" class="container" action="https://<?php echo $this->domain; ?>.sendsmaily.net/api/opt-in/" method="post">
+<form id="smly" action="https://<?php echo $this->domain; ?>.sendsmaily.net/api/opt-in/" method="post">
 	<p class="error" style="padding:15px;background-color:#f2dede;margin:0 0 10px;display:<?php echo $this->form_has_response ? 'block' : 'none'; ?>"><?php echo esc_html( $this->response_message ); ?></p>
 	<p class="success" style="padding:15px;background-color:#dff0d8;margin:0 0 10px;display:<?php echo $this->form_is_successful ? 'block' : 'none'; ?>"><?php echo esc_html__( 'Thank you for subscribing to our newsletter.', 'wp_smaily' ); ?></p>
 	<input type="hidden" name="lang" value="<?php echo ( defined( 'ICL_LANGUAGE_CODE' ) ) ? ICL_LANGUAGE_CODE : ''; ?>" />


### PR DESCRIPTION
> Form class name container is too generic and can conflict with WordPress theme styles.

Closes #52