### PR TITLE
Wordpress 5.6 compatibility tested

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
 === Smaily for WP ===
-Contributors: sendsmaily, kaarel, tomabel
+Contributors: sendsmaily, kaarel, tomabel, marispulk
 License: GPLv2 or later
 Requires PHP: 5.6
 Requires at least: 4.0
 Stable tag: 2.2.1
 Tags: widget, plugin, sidebar, api, mail, email, marketing, smaily
-Tested up to: 5.4.1
+Tested up to: 5.6.0
 
 Smaily newsletter subscription plugin for WordPress
 


### PR DESCRIPTION
- Tested WordPress 5.6.0 compatibility with Smaily for WordPress plugin.

