### PR TITLE
Use config authentication for phpMyAdmin image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       MYSQL_ROOT_PASSWORD: smailydev1
     volumes:
       - db:/var/lib/mysql
+
   phpmyadmin:
     depends_on:
       - db
@@ -30,6 +31,8 @@ services:
       - '8888:80'
     environment:
       PMA_HOST: db
+      PMA_USER: root
+      PMA_PASSWORD: smailydev1
       MYSQL_ROOT_PASSWORD: smailydev1
 volumes:
   wordpress:


### PR DESCRIPTION
If login credentials are specified as environment variables, then phpMyAdmin will switch from [cookie authentication](https://docs.phpmyadmin.net/en/latest/setup.html#cookie) to [config authentication](https://docs.phpmyadmin.net/en/latest/setup.html#auth-config) mode. 

Instead of entering credentials, login will happen automatically on visit. Helpful for development.


