### PR TITLE
Use options API in lieu of storing data in an SQL table

### DIFF
--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -395,7 +395,7 @@ class Smaily_For_WP_Admin {
 		// Load configuration data.
 		$api_credentials = $this->options->get_api_credentials();
 
-		if ( ! $this->options->has_credentials( $api_credentials ) ) {
+		if ( ! $this->options->has_credentials() ) {
 			return array();
 		}
 

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -31,9 +31,9 @@ class Smaily_For_WP_Admin {
 	 *
 	 * @since  3.0.0
 	 * @access private
-	 * @var    Smaily_For_WP_Option_Handler Handler for Options API.
+	 * @var    Smaily_For_WP_Options Handler for WordPress Options API.
 	 */
-	private $option_handler;
+	private $options;
 
 	/**
 	 * Initialize the class and set its properties.
@@ -45,7 +45,7 @@ class Smaily_For_WP_Admin {
 	public function __construct( $plugin_name, $version ) {
 		$this->plugin_name    = $plugin_name;
 		$this->version        = $version;
-		$this->option_handler = new Smaily_For_WP_Option_Handler();
+		$this->option_handler = new Smaily_For_WP_Options();
 	}
 
 	/**

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -319,7 +319,7 @@ class Smaily_For_WP_Admin {
 	 *
 	 * @since  3.0.0
 	 * @access private
-	 * @param  string $template_name            Name of template file to use, without any prefixes (i.e form.php).
+	 * @param  string $template_name            Name of template file to use, without any prefixes (e.g form.php).
 	 * @param  bool   $has_credentials          User has saved valid credentials? Yes/No.
 	 * @param  string $newsletter_form          HTML of newsletter subscription form.
 	 * @return Smaily_For_WP_Template $template Template of admin form.
@@ -343,7 +343,7 @@ class Smaily_For_WP_Admin {
 	 *
 	 * @since  3.0.0
 	 * @access private
-	 * @param  string $template_name            Name of template file to use, without any prefixes (i.e advanced.php).
+	 * @param  string $template_name            Name of template file to use, without any prefixes (e.g advanced.php).
 	 * @param  string $subdomain                Smaily API subdomain.
 	 * @param  string $newsletter_form          HTML of newsletter subscription form.
 	 * @return Smaily_For_WP_Template $template Template of admin form.

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -80,12 +80,12 @@ class Smaily_For_WP_Admin {
 		$api_credentials = get_option( 'smailyforwp_api_option' );
 		$form_options    = get_option( 'smailyforwp_form_option' );
 
-		$credentials_set = ! empty( $api_credentials['subdomain'] ) && ! empty( $api_credentials['username'] ) && ! empty( $api_credentials['password'] );
+		$has_credentials = ! empty( $api_credentials['subdomain'] ) && ! empty( $api_credentials['username'] ) && ! empty( $api_credentials['password'] );
 
 		$template->assign(
 			array(
-				'form'                => isset( $form_options['form'] ) ? $form_options['form'] : '',
-				'api_credentials_set' => $credentials_set,
+				'form'            => isset( $form_options['form'] ) ? $form_options['form'] : '',
+				'has_credentials' => $has_credentials,
 			)
 		);
 
@@ -176,12 +176,12 @@ class Smaily_For_WP_Admin {
 		// Load configuration data.
 		$api_credentials = get_option( 'smailyforwp_api_option' );
 		$form_options    = get_option( 'smailyforwp_form_option' );
-		$credentials_set = ! empty( $api_credentials['subdomain'] ) && ! empty( $api_credentials['username'] ) && ! empty( $api_credentials['password'] );
+		$has_credentials = ! empty( $api_credentials['subdomain'] ) && ! empty( $api_credentials['username'] ) && ! empty( $api_credentials['password'] );
 
 		$template->assign(
 			array(
-				'form'                => $form_options['form'],
-				'api_credentials_set' => $credentials_set,
+				'form'            => $form_options['form'],
+				'has_credentials' => $has_credentials,
 			)
 		);
 

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -394,8 +394,7 @@ class Smaily_For_WP_Admin {
 		// Load configuration data.
 		$api_credentials = $this->option_handler->get_api_credentials();
 
-		$credentials_not_valid = empty( $api_credentials['subdomain'] ) || empty( $api_credentials['username'] ) || empty( $api_credentials['password'] );
-		if ( $credentials_not_valid ) {
+		if ( ! $this->option_handler->has_credentials( $api_credentials ) ) {
 			return array();
 		}
 

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -173,30 +173,6 @@ class Smaily_For_WP_Admin {
 	}
 
 	/**
-	 * Generate admin area template and assign required variables via function parameters.
-	 *
-	 * @since  3.0.0
-	 * @access private
-	 * @param  string $template_name            Name of template file to use, without any prefixes (i.e form.php).
-	 * @param  bool   $has_credentials          User has saved valid credentials? Yes/No.
-	 * @param  string $newsletter_form          HTML of newsletter subscription form.
-	 * @return Smaily_For_WP_Template $template Template of admin form.
-	 */
-	private function generate_admin_template( $template_name, $has_credentials, $newsletter_form ) {
-		// Generate form contents.
-		$template = new Smaily_For_WP_Template( 'admin/partials/smaily-for-wp-admin-' . $template_name );
-
-		$template->assign(
-			array(
-				'has_credentials' => $has_credentials,
-				'form'            => $newsletter_form,
-			)
-		);
-
-		return $template;
-	}
-
-	/**
 	 * Function is run when user submits Smaily API credentials.
 	 *
 	 * @since  3.0.0
@@ -288,29 +264,6 @@ class Smaily_For_WP_Admin {
 	}
 
 	/**
-	 * Generate newsletter signup template and assign required variables via function parameters.
-	 *
-	 * @since  3.0.0
-	 * @access private
-	 * @param  string $template_name            Name of template file to use, without any prefixes (i.e advanced.php).
-	 * @param  string $subdomain                Smaily API subdomain.
-	 * @param  string $newsletter_form          HTML of newsletter subscription form.
-	 * @return Smaily_For_WP_Template $template Template of admin form.
-	 */
-	private function generate_signup_template( $template_name, $subdomain, $newsletter_form = '' ) {
-		// Generate form contents.
-		$template = new Smaily_For_WP_Template( 'public/partials/smaily-for-wp-public-' . $template_name );
-
-		$template->assign(
-			array(
-				'domain' => $subdomain,
-				'form'   => $newsletter_form,
-			)
-		);
-		return $template;
-	}
-
-	/**
 	 * Function is run when user presses save button.
 	 *
 	 * @since  3.0.0
@@ -346,6 +299,54 @@ class Smaily_For_WP_Admin {
 			'error'   => false,
 			'message' => __( 'Changes saved.', 'smaily-for-wp' ),
 		);
+	}
+
+
+	/**
+	 * Generate admin area template and assign required variables via function parameters.
+	 *
+	 * @since  3.0.0
+	 * @access private
+	 * @param  string $template_name            Name of template file to use, without any prefixes (i.e form.php).
+	 * @param  bool   $has_credentials          User has saved valid credentials? Yes/No.
+	 * @param  string $newsletter_form          HTML of newsletter subscription form.
+	 * @return Smaily_For_WP_Template $template Template of admin form.
+	 */
+	private function generate_admin_template( $template_name, $has_credentials, $newsletter_form ) {
+		// Generate form contents.
+		$template = new Smaily_For_WP_Template( 'admin/partials/smaily-for-wp-admin-' . $template_name );
+
+		$template->assign(
+			array(
+				'has_credentials' => $has_credentials,
+				'form'            => $newsletter_form,
+			)
+		);
+
+		return $template;
+	}
+
+	/**
+	 * Generate newsletter signup template and assign required variables via function parameters.
+	 *
+	 * @since  3.0.0
+	 * @access private
+	 * @param  string $template_name            Name of template file to use, without any prefixes (i.e advanced.php).
+	 * @param  string $subdomain                Smaily API subdomain.
+	 * @param  string $newsletter_form          HTML of newsletter subscription form.
+	 * @return Smaily_For_WP_Template $template Template of admin form.
+	 */
+	private function generate_signup_template( $template_name, $subdomain, $newsletter_form = '' ) {
+		// Generate form contents.
+		$template = new Smaily_For_WP_Template( 'public/partials/smaily-for-wp-public-' . $template_name );
+
+		$template->assign(
+			array(
+				'domain' => $subdomain,
+				'form'   => $newsletter_form,
+			)
+		);
+		return $template;
 	}
 
 	/**

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -358,8 +358,8 @@ class Smaily_For_WP_Admin {
 	 *
 	 * @since  3.0.0
 	 * @access private
-	 * @param  string  $subdomain Messy subdomain, e.g http://demo.sendsmaily.net
-	 * @return string  Clean subdomain, e.g demo
+	 * @param  string $subdomain Messy subdomain, e.g http://demo.sendsmaily.net
+	 * @return string Clean subdomain, e.g demo
 	 */
 	private function normalize_subdomain( $subdomain ) {
 		// Normalize subdomain.

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -45,7 +45,7 @@ class Smaily_For_WP_Admin {
 	public function __construct( $plugin_name, $version ) {
 		$this->plugin_name    = $plugin_name;
 		$this->version        = $version;
-		$this->option_handler = new Smaily_For_WP_Options();
+		$this->options = new Smaily_For_WP_Options();
 	}
 
 	/**
@@ -84,8 +84,8 @@ class Smaily_For_WP_Admin {
 	 */
 	public function smaily_admin_render() {
 		// Load configuration data.
-		$has_credentials = $this->option_handler->has_credentials();
-		$form_options    = $this->option_handler->get_form_options();
+		$has_credentials = $this->options->has_credentials();
+		$form_options    = $this->options->get_form_options();
 
 		// Create admin template.
 		$template = $this->generate_admin_template( 'page.php', $has_credentials, $form_options['form'] );
@@ -156,8 +156,8 @@ class Smaily_For_WP_Admin {
 		}
 
 		if ( $refresh && $result['error'] === false ) {
-			$has_credentials   = $this->option_handler->has_credentials();
-			$signup_form       = $this->option_handler->get_form_options()['form'];
+			$has_credentials   = $this->options->has_credentials();
+			$signup_form       = $this->options->get_form_options()['form'];
 			$result['content'] = $this->generate_admin_template( 'form.php', $has_credentials, $signup_form )->render();
 		}
 
@@ -229,7 +229,7 @@ class Smaily_For_WP_Admin {
 			);
 		}
 		// Insert item to database.
-		$this->option_handler->update_api_credentials( $params );
+		$this->options->update_api_credentials( $params );
 
 		// Return result.
 		return array(
@@ -247,7 +247,7 @@ class Smaily_For_WP_Admin {
 	 */
 	private function remove_api_key() {
 		// Delete contents of config.
-		$this->option_handler->update_api_credentials( array() );
+		$this->options->update_api_credentials( array() );
 
 		// Set result.
 		return array(
@@ -264,7 +264,7 @@ class Smaily_For_WP_Admin {
 	 * @return array Response of operation.
 	 */
 	private function reset_form() {
-		$subdomain = $this->option_handler->get_api_credentials()['subdomain'];
+		$subdomain = $this->options->get_api_credentials()['subdomain'];
 		$template  = $this->generate_signup_template( 'advanced.php', $subdomain );
 
 		return array(
@@ -290,15 +290,15 @@ class Smaily_For_WP_Admin {
 		// Generate new form (if empty).
 		if ( empty( $form ) ) {
 			// Load configuration data.
-			$subdomain = $this->option_handler->get_api_credentials()['subdomain'];
-			$form      = $this->option_handler->get_form_options()['form'];
+			$subdomain = $this->options->get_api_credentials()['subdomain'];
+			$form      = $this->options->get_form_options()['form'];
 
 			$template = $this->generate_signup_template( 'advanced.php', $subdomain, $form );
 			// Render template.
 			$form = trim( $template->render() );
 		}
 
-		$this->option_handler->update_form_options(
+		$this->options->update_form_options(
 			array(
 				'is_advanced' => $is_advanced,
 				'form'        => $form,
@@ -392,9 +392,9 @@ class Smaily_For_WP_Admin {
 	 */
 	public function get_autoresponders() {
 		// Load configuration data.
-		$api_credentials = $this->option_handler->get_api_credentials();
+		$api_credentials = $this->options->get_api_credentials();
 
-		if ( ! $this->option_handler->has_credentials( $api_credentials ) ) {
+		if ( ! $this->options->has_credentials( $api_credentials ) ) {
 			return array();
 		}
 

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -350,11 +350,12 @@ class Smaily_For_WP_Admin {
 			$form = ltrim( $template->render() );
 		}
 
-		$form_options = array(
-			'is_advanced' => $is_advanced,
-			'form'        => $form,
+		$this->option_handler->update_form_options(
+			array(
+				'is_advanced' => $is_advanced,
+				'form'        => $form,
+			)
 		);
-		$this->option_handler->update_form_options( $form_options );
 
 		// Return response.
 		return array(

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -85,10 +85,10 @@ class Smaily_For_WP_Admin {
 	public function smaily_admin_render() {
 		// Load configuration data.
 		$has_credentials = $this->options->has_credentials();
-		$form_options    = $this->options->get_form_options();
+		$signup_form     = $this->options->get_form_options()['form'];
 
 		// Create admin template.
-		$template = $this->generate_admin_template( 'page.php', $has_credentials, $form_options['form'] );
+		$template = $this->generate_admin_template( 'page.php', $has_credentials, $signup_form );
 
 		// Add menu elements.
 		add_menu_page( 'smaily', 'Smaily', 'manage_options', SMLY4WP_PLUGIN_PATH, '', SMLY4WP_PLUGIN_URL . '/gfx/icon.png' );

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -165,7 +165,9 @@ class Smaily_For_WP_Admin {
 		}
 
 		if ( $refresh && $result['error'] === false ) {
-			$result['content'] = $this->generate_admin_form();
+			$has_credentials   = $this->option_handler->has_credentials();
+			$signup_form       = $this->option_handler->get_form_options()['form'];
+			$result['content'] = $this->generate_admin_template( 'form.php', $has_credentials, $signup_form )->render();
 		}
 
 		echo wp_json_encode( $result );
@@ -173,30 +175,27 @@ class Smaily_For_WP_Admin {
 	}
 
 	/**
-	 * Regenerate admin form using options stored in DB.
+	 * Generate admin area template and assign required variables via function parameters.
 	 *
 	 * @since  3.0.0
 	 * @access private
-	 * @return string HTML of admin form.
+	 * @param  string $template_name            Name of template file to use, without any prefixes (i.e form.php).
+	 * @param  bool   $has_credentials          User has saved valid credentials? Yes/No.
+	 * @param  string $newsletter_form          HTML of newsletter subscription form.
+	 * @return Smaily_For_WP_Template $template Template of admin form.
 	 */
-	private function generate_admin_form() {
+	private function generate_admin_template( $template_name, $has_credentials, $newsletter_form ) {
 		// Generate form contents.
-		$template = new Smaily_For_WP_Template( 'admin/partials/smaily-for-wp-admin-form.php' );
-
-		// Load configuration data.
-		$api_credentials = $this->option_handler->get_api_credentials();
-		$form_options    = $this->option_handler->get_form_options();
-		$has_credentials = ! empty( $api_credentials['subdomain'] ) && ! empty( $api_credentials['username'] ) && ! empty( $api_credentials['password'] );
+		$template = new Smaily_For_WP_Template( 'admin/partials/smaily-for-wp-admin-' . $template_name );
 
 		$template->assign(
 			array(
-				'form'            => $form_options['form'],
 				'has_credentials' => $has_credentials,
+				'form'            => $newsletter_form,
 			)
 		);
 
-		// Render template.
-		return $template->render();
+		return $template;
 	}
 
 	/**

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -83,21 +83,12 @@ class Smaily_For_WP_Admin {
 	 * @since 3.0.0
 	 */
 	public function smaily_admin_render() {
-		// Create admin template.
-		$template = new Smaily_For_WP_Template( 'admin/partials/smaily-for-wp-admin-page.php' );
-
 		// Load configuration data.
-		$api_credentials = $this->option_handler->get_api_credentials();
+		$has_credentials = $this->option_handler->has_credentials();
 		$form_options    = $this->option_handler->get_form_options();
 
-		$has_credentials = ! empty( $api_credentials['subdomain'] ) && ! empty( $api_credentials['username'] ) && ! empty( $api_credentials['password'] );
-
-		$template->assign(
-			array(
-				'form'            => $form_options['form'],
-				'has_credentials' => $has_credentials,
-			)
-		);
+		// Create admin template.
+		$template = $this->generate_admin_template( 'page.php', $has_credentials, $form_options['form'] );
 
 		// Add menu elements.
 		add_menu_page( 'smaily', 'Smaily', 'manage_options', SMLY4WP_PLUGIN_PATH, '', SMLY4WP_PLUGIN_URL . '/gfx/icon.png' );

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -94,7 +94,7 @@ class Smaily_For_WP_Admin {
 
 		$template->assign(
 			array(
-				'form'            => isset( $form_options['form'] ) ? $form_options['form'] : '',
+				'form'            => $form_options['form'],
 				'has_credentials' => $has_credentials,
 			)
 		);
@@ -304,7 +304,7 @@ class Smaily_For_WP_Admin {
 		$api_credentials = $this->option_handler->get_api_credentials();
 		$template->assign(
 			array(
-				'domain' => isset( $api_credentials['subdomain'] ) ? $api_credentials['subdomain'] : '',
+				'domain' => $api_credentials['subdomain'],
 				'form'   => '',
 			)
 		);
@@ -340,8 +340,8 @@ class Smaily_For_WP_Admin {
 
 			$template->assign(
 				array(
-					'domain' => isset( $api_credentials['subdomain'] ) ? $api_credentials['subdomain'] : '',
-					'form'   => isset( $form_options['form'] ) ? $form_options['form'] : '',
+					'domain' => $api_credentials['subdomain'],
+					'form'   => $form_options['form']
 				)
 			);
 

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -39,13 +39,14 @@ class Smaily_For_WP_Admin {
 	 * Initialize the class and set its properties.
 	 *
 	 * @since 3.0.0
-	 * @param string $plugin_name The name of this plugin.
-	 * @param string $version     The version of this plugin.
+	 * @param Smaily_For_WP_Options $options     Reference to option handler class.
+	 * @param string                $plugin_name The name of this plugin.
+	 * @param string                $version     The version of this plugin.
 	 */
-	public function __construct( $plugin_name, $version ) {
-		$this->plugin_name    = $plugin_name;
-		$this->version        = $version;
-		$this->options = new Smaily_For_WP_Options();
+	public function __construct( Smaily_For_WP_Options $options, $plugin_name, $version ) {
+		$this->options     = $options;
+		$this->plugin_name = $plugin_name;
+		$this->version     = $version;
 	}
 
 	/**
@@ -101,7 +102,7 @@ class Smaily_For_WP_Admin {
 	 * @since 3.0.0
 	 */
 	public function smaily_subscription_widget_init() {
-		$widget = new Smaily_For_WP_Widget( $this );
+		$widget = new Smaily_For_WP_Widget( $this->options, $this );
 		register_widget( $widget );
 	}
 
@@ -246,8 +247,7 @@ class Smaily_For_WP_Admin {
 	 * @return array Response of operation.
 	 */
 	private function remove_api_key() {
-		// Delete contents of config.
-		$this->options->update_api_credentials( array() );
+		$this->options->remove_api_credentials();
 
 		// Return response.
 		return array(

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -231,7 +231,7 @@ class Smaily_For_WP_Admin {
 		// Insert item to database.
 		$this->options->update_api_credentials( $params );
 
-		// Return result.
+		// Return response.
 		return array(
 			'error'   => false,
 			'message' => __( 'Credentials validated.', 'smaily-for-wp' ),
@@ -249,7 +249,7 @@ class Smaily_For_WP_Admin {
 		// Delete contents of config.
 		$this->options->update_api_credentials( array() );
 
-		// Set result.
+		// Return response.
 		return array(
 			'error'   => false,
 			'message' => __( 'Credentials removed.', 'smaily-for-wp' ),
@@ -267,6 +267,7 @@ class Smaily_For_WP_Admin {
 		$subdomain = $this->options->get_api_credentials()['subdomain'];
 		$template  = $this->generate_signup_template( 'advanced.php', $subdomain );
 
+		// Return response.
 		return array(
 			'message' => __( 'Newsletter subscription form reset to default.', 'smaily-for-wp' ),
 			'error'   => false,

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -148,14 +148,7 @@ class Smaily_For_WP_Admin {
 				$result = array_merge( $result, $this->remove_api_key() );
 				break;
 			case 'resetForm':
-				$subdomain = $this->option_handler->get_api_credentials()['subdomain'];
-				$template  = $this->generate_signup_template( 'advanced.php', $subdomain );
-
-				$result = array(
-					'message' => __( 'Newsletter subscription form reset to default.', 'smaily-for-wp' ),
-					'error'   => false,
-					'content' => $template->render(),
-				);
+				$result = array_merge( $result, $this->reset_form() );
 				break;
 			case 'save':
 				$result = array_merge( $result, $this->save( $form_data ) );
@@ -260,6 +253,24 @@ class Smaily_For_WP_Admin {
 		return array(
 			'error'   => false,
 			'message' => __( 'Credentials removed.', 'smaily-for-wp' ),
+		);
+	}
+
+	/**
+	 * Function is run when user regenerates signup form.
+	 *
+	 * @since  3.0.0
+	 * @access private
+	 * @return array Response of operation.
+	 */
+	private function reset_form() {
+		$subdomain = $this->option_handler->get_api_credentials()['subdomain'];
+		$template  = $this->generate_signup_template( 'advanced.php', $subdomain );
+
+		return array(
+			'message' => __( 'Newsletter subscription form reset to default.', 'smaily-for-wp' ),
+			'error'   => false,
+			'content' => $template->render(),
 		);
 	}
 

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -325,19 +325,11 @@ class Smaily_For_WP_Admin {
 
 		// Generate new form (if empty).
 		if ( empty( $form ) ) {
-			$template = new Smaily_For_WP_Template( 'public/partials/smaily-for-wp-public-advanced.php' );
-
 			// Load configuration data.
-			$api_credentials = $this->option_handler->get_api_credentials();
-			$form_options    = $this->option_handler->get_form_options();
+			$subdomain = $this->option_handler->get_api_credentials()['subdomain'];
+			$form      = $this->option_handler->get_form_options()['form'];
 
-			$template->assign(
-				array(
-					'domain' => $api_credentials['subdomain'],
-					'form'   => $form_options['form'],
-				)
-			);
-
+			$template = $this->generate_signup_template( 'advanced.php', $subdomain, $form );
 			// Render template.
 			$form = ltrim( $template->render() );
 		}

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -295,7 +295,7 @@ class Smaily_For_WP_Admin {
 
 			$template = $this->generate_signup_template( 'advanced.php', $subdomain, $form );
 			// Render template.
-			$form = ltrim( $template->render() );
+			$form = trim( $template->render() );
 		}
 
 		$this->option_handler->update_form_options(

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -148,7 +148,14 @@ class Smaily_For_WP_Admin {
 				$result = array_merge( $result, $this->remove_api_key() );
 				break;
 			case 'resetForm':
-				$result = array_merge( $result, $this->reset_form() );
+				$subdomain = $this->option_handler->get_api_credentials()['subdomain'];
+				$template  = $this->generate_signup_template( 'advanced.php', $subdomain );
+
+				$result = array(
+					'message' => __( 'Newsletter subscription form reset to default.', 'smaily-for-wp' ),
+					'error'   => false,
+					'content' => $template->render(),
+				);
 				break;
 			case 'save':
 				$result = array_merge( $result, $this->save( $form_data ) );
@@ -280,32 +287,27 @@ class Smaily_For_WP_Admin {
 		);
 	}
 
-
 	/**
-	 * Function is run when user regenerates signup form.
+	 * Generate newsletter signup template and assign required variables via function parameters.
 	 *
 	 * @since  3.0.0
 	 * @access private
-	 * @return array Response of operation.
+	 * @param  string $template_name            Name of template file to use, without any prefixes (i.e advanced.php).
+	 * @param  string $subdomain                Smaily API subdomain.
+	 * @param  string $newsletter_form          HTML of newsletter subscription form.
+	 * @return Smaily_For_WP_Template $template Template of admin form.
 	 */
-	private function reset_form() {
+	private function generate_signup_template( $template_name, $subdomain, $newsletter_form = '' ) {
 		// Generate form contents.
-		$template = new Smaily_For_WP_Template( 'public/partials/smaily-for-wp-public-advanced.php' );
+		$template = new Smaily_For_WP_Template( 'public/partials/smaily-for-wp-public-' . $template_name );
 
-		$api_credentials = $this->option_handler->get_api_credentials();
 		$template->assign(
 			array(
-				'domain' => $api_credentials['subdomain'],
-				'form'   => '',
+				'domain' => $subdomain,
+				'form'   => $newsletter_form,
 			)
 		);
-
-		// Render template.
-		return array(
-			'error'   => false,
-			'message' => __( 'Newsletter subscription form reset to default.', 'smaily-for-wp' ),
-			'content' => $template->render(),
-		);
+		return $template;
 	}
 
 	/**
@@ -332,7 +334,7 @@ class Smaily_For_WP_Admin {
 			$template->assign(
 				array(
 					'domain' => $api_credentials['subdomain'],
-					'form'   => $form_options['form']
+					'form'   => $form_options['form'],
 				)
 			);
 

--- a/admin/partials/smaily-for-wp-admin-form.php
+++ b/admin/partials/smaily-for-wp-admin-form.php
@@ -1,5 +1,5 @@
 <?php
-$api_credentials_set = $this->api_credentials_set;
+$has_credentials = $this->has_credentials;
 ?>
 
 <div>
@@ -7,7 +7,7 @@ $api_credentials_set = $this->api_credentials_set;
 	<input type="hidden" name="is_advanced" value="0" />
 </div>
 
-<?php if ( $api_credentials_set ) : ?>
+<?php if ( $has_credentials ) : ?>
 <p>
 	<span><?php echo esc_html__( 'Your API credentials are valid', 'smaily-for-wp' ); ?></span>
 	<a href="#" onclick="javascript:Default.removeApiKey();return false;"><strong><?php echo esc_html__( 'Remove', 'smaily-for-wp' ); ?></strong><img src="<?php echo SMLY4WP_PLUGIN_URL; ?>/gfx/remove.png" alt="<?php echo esc_html__( 'Remove', 'smaily-for-wp' ); ?>" title="<?php echo esc_html__( 'Remove', 'smaily-for-wp' ); ?>" /></a>
@@ -47,7 +47,7 @@ $api_credentials_set = $this->api_credentials_set;
 </div>
 <?php endif; ?>
 
-<?php if ( $api_credentials_set ) : ?>
+<?php if ( $has_credentials ) : ?>
 <ul class="tabs">
 	<li><a id="link-basic" href="#basic" class="selected"><?php echo esc_html__( 'Basic', 'smaily-for-wp' ); ?></a></li>
 	<li><a id="link-advanced" href="#advanced"><?php echo esc_html__( 'Advanced', 'smaily-for-wp' ); ?></a></li>

--- a/admin/partials/smaily-for-wp-admin-form.php
+++ b/admin/partials/smaily-for-wp-admin-form.php
@@ -1,13 +1,9 @@
-<?php
-$has_credentials = $this->has_credentials;
-?>
-
 <div>
 	<input type="hidden" name="op" value="save" />
 	<input type="hidden" name="is_advanced" value="0" />
 </div>
 
-<?php if ( $has_credentials ) : ?>
+<?php if ( $this->has_credentials ) : ?>
 <p>
 	<span><?php echo esc_html__( 'Your API credentials are valid', 'smaily-for-wp' ); ?></span>
 	<a href="#" onclick="javascript:Default.removeApiKey();return false;"><strong><?php echo esc_html__( 'Remove', 'smaily-for-wp' ); ?></strong><img src="<?php echo SMLY4WP_PLUGIN_URL; ?>/gfx/remove.png" alt="<?php echo esc_html__( 'Remove', 'smaily-for-wp' ); ?>" title="<?php echo esc_html__( 'Remove', 'smaily-for-wp' ); ?>" /></a>
@@ -47,7 +43,7 @@ $has_credentials = $this->has_credentials;
 </div>
 <?php endif; ?>
 
-<?php if ( $has_credentials ) : ?>
+<?php if ( $this->has_credentials ) : ?>
 <ul class="tabs">
 	<li><a id="link-basic" href="#basic" class="selected"><?php echo esc_html__( 'Basic', 'smaily-for-wp' ); ?></a></li>
 	<li><a id="link-advanced" href="#advanced"><?php echo esc_html__( 'Advanced', 'smaily-for-wp' ); ?></a></li>

--- a/admin/partials/smaily-for-wp-admin-form.php
+++ b/admin/partials/smaily-for-wp-admin-form.php
@@ -1,5 +1,5 @@
 <?php
-$api_credentials = $this->api_credentials;
+$api_credentials_set = $this->api_credentials_set;
 ?>
 
 <div>
@@ -7,7 +7,7 @@ $api_credentials = $this->api_credentials;
 	<input type="hidden" name="is_advanced" value="0" />
 </div>
 
-<?php if ( ! empty( $api_credentials ) ) : ?>
+<?php if ( $api_credentials_set ) : ?>
 <p>
 	<span><?php echo esc_html__( 'Your API credentials are valid', 'smaily-for-wp' ); ?></span>
 	<a href="#" onclick="javascript:Default.removeApiKey();return false;"><strong><?php echo esc_html__( 'Remove', 'smaily-for-wp' ); ?></strong><img src="<?php echo SMLY4WP_PLUGIN_URL; ?>/gfx/remove.png" alt="<?php echo esc_html__( 'Remove', 'smaily-for-wp' ); ?>" title="<?php echo esc_html__( 'Remove', 'smaily-for-wp' ); ?>" /></a>
@@ -47,7 +47,7 @@ $api_credentials = $this->api_credentials;
 </div>
 <?php endif; ?>
 
-<?php if ( ! empty( $api_credentials ) ) : ?>
+<?php if ( $api_credentials_set ) : ?>
 <ul class="tabs">
 	<li><a id="link-basic" href="#basic" class="selected"><?php echo esc_html__( 'Basic', 'smaily-for-wp' ); ?></a></li>
 	<li><a id="link-advanced" href="#advanced"><?php echo esc_html__( 'Advanced', 'smaily-for-wp' ); ?></a></li>
@@ -58,7 +58,7 @@ $api_credentials = $this->api_credentials;
 	<div class="wrap">
 		<label><?php echo esc_html__( 'Newsletter subscription form', 'smaily-for-wp' ); ?> <a href="#" onclick="javascript:Default.resetForm();return false;" title="<?php echo esc_html__( 'Restore original subscription form', 'smaily-for-wp' ); ?>">(<?php echo esc_html__( 'Regenerate', 'smaily-for-wp' ); ?>)</a></label>
 		<em><?php echo esc_html__( 'HTML of subscription form', 'smaily-for-wp' ); ?></em>
-		<textarea id="advanced-form" name="advanced[form]" rows="15"><?php echo stripslashes( $this->form ); ?></textarea>
+		<textarea id="advanced-form" name="form" rows="15"><?php echo esc_textarea( $this->form ); ?></textarea>
 	</div>
 </div>
 

--- a/includes/class-smaily-for-wp-i18n.php
+++ b/includes/class-smaily-for-wp-i18n.php
@@ -17,7 +17,7 @@ class Smaily_For_WP_i18n {
 		load_plugin_textdomain(
 			'smaily-for-wp',
 			false,
-			plugin_basename( SMLY4WP_PLUGIN_PATH ) . 'lang/'
+			plugin_basename( SMLY4WP_PLUGIN_PATH ) . '/lang/'
 		);
 	}
 }

--- a/includes/class-smaily-for-wp-lifecycle.php
+++ b/includes/class-smaily-for-wp-lifecycle.php
@@ -40,6 +40,8 @@ class Smaily_For_WP_Lifecycle {
 	 * @since 3.0.0
 	 */
 	public static function uninstall() {
+		delete_option( 'smailyforwp_api_option' );
+		delete_option( 'smailyforwp_form_option' );
 		delete_option( 'widget_smaily_subscription_widget' );
 		delete_option( 'smailyforwp_db_version' );
 		delete_transient( 'smailyforwp_plugin_updated' );

--- a/includes/class-smaily-for-wp-lifecycle.php
+++ b/includes/class-smaily-for-wp-lifecycle.php
@@ -15,21 +15,6 @@ class Smaily_For_WP_Lifecycle {
 	 */
 	public function activate() {
 		$this->run_migrations();
-
-		global $wpdb;
-		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-		$charset_collate = $wpdb->get_charset_collate();
-
-		// Create database table - settings.
-		$table_name = esc_sql( $wpdb->prefix . 'smaily_config' );
-		$sql        = "CREATE TABLE $table_name (
-			api_credentials VARCHAR(128) NOT NULL,
-			domain VARCHAR(255) NOT NULL,
-			form TEXT NOT NULL,
-			is_advanced TINYINT(1) NOT NULL,
-			PRIMARY KEY  (api_credentials)
-		) $charset_collate;";
-		dbDelta( $sql );
 	}
 
 	/**

--- a/includes/class-smaily-for-wp-lifecycle.php
+++ b/includes/class-smaily-for-wp-lifecycle.php
@@ -40,8 +40,6 @@ class Smaily_For_WP_Lifecycle {
 	 * @since 3.0.0
 	 */
 	public static function uninstall() {
-		global $wpdb;
-		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}smaily_config" );
 		delete_option( 'widget_smaily_subscription_widget' );
 		delete_option( 'smailyforwp_db_version' );
 		delete_transient( 'smailyforwp_plugin_updated' );

--- a/includes/class-smaily-for-wp-option-handler.php
+++ b/includes/class-smaily-for-wp-option-handler.php
@@ -18,9 +18,9 @@ class Smaily_For_WP_Option_Handler {
 		$credentials = get_option( 'smailyforwp_api_option', array() );
 		return array_merge(
 			array(
-				'subdomain' => null,
-				'username'  => null,
-				'password'  => null,
+				'subdomain' => '',
+				'username'  => '',
+				'password'  => '',
 			),
 			$credentials
 		);
@@ -36,8 +36,8 @@ class Smaily_For_WP_Option_Handler {
 		$form_options = get_option( 'smailyforwp_form_option', array() );
 		return array_merge(
 			array(
-				'form'        => null,
-				'is_advanced' => null,
+				'form'        => '',
+				'is_advanced' => '',
 			),
 			$form_options
 		);

--- a/includes/class-smaily-for-wp-option-handler.php
+++ b/includes/class-smaily-for-wp-option-handler.php
@@ -69,6 +69,7 @@ class Smaily_For_WP_Option_Handler {
 	 *
 	 * @since  3.0.0
 	 * @access private
+	 * @param  array $credentials Smaily API credentials.
 	 * @return boolean User has saved credentials to DB.
 	 */
 	public function has_credentials( $credentials = null ) {

--- a/includes/class-smaily-for-wp-option-handler.php
+++ b/includes/class-smaily-for-wp-option-handler.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Define the plugin's reading and writing functionality, from and to WordPress' options table.
+ *
+ * @since      3.0.0
+ * @package    Smaily_For_WP
+ * @subpackage Smaily_For_WP/includes
+ */
+class Smaily_For_WP_Option_Handler {
+
+	/**
+	 * Get API credentials stored in database.
+	 *
+	 * @since  3.0.0
+	 * @return array API credentials in proper format.
+	 */
+	public function get_api_credentials() {
+		$credentials = get_option( 'smailyforwp_api_option', array() );
+		return array_merge(
+			array(
+				'subdomain' => null,
+				'username'  => null,
+				'password'  => null,
+			),
+			$credentials
+		);
+	}
+
+	/**
+	 * Get form options stored in database.
+	 *
+	 * @since  3.0.0
+	 * @return array Form options in proper format
+	 */
+	public function get_form_options() {
+		$form_options = get_option( 'smailyforwp_form_option', array() );
+		return array_merge(
+			array(
+				'form'        => null,
+				'is_advanced' => null,
+			),
+			$form_options
+		);
+	}
+
+	/**
+	 * Overwrite API credentials entry in database with provided parameter.
+	 * Disable auto-loading as API credentials are delicate.
+	 *
+	 * @since 3.0.0
+	 * @param array $api_credentials Smaily API credentials.
+	 */
+	public function update_api_credentials( $api_credentials ) {
+		update_option( 'smailyforwp_api_option', $api_credentials, false );
+	}
+
+	/**
+	 * Overwrite form options entry in database with provided parameter.
+	 *
+	 * @since 3.0.0
+	 * @param array $form_options Newsletter form options.
+	 */
+	public function update_form_options( $form_options ) {
+		update_option( 'smailyforwp_form_option', $form_options );
+	}
+}

--- a/includes/class-smaily-for-wp-option-handler.php
+++ b/includes/class-smaily-for-wp-option-handler.php
@@ -63,4 +63,16 @@ class Smaily_For_WP_Option_Handler {
 	public function update_form_options( $form_options ) {
 		update_option( 'smailyforwp_form_option', $form_options );
 	}
+
+	/**
+	 * Has user saved valid Smaily API credentials to database.
+	 *
+	 * @since  3.0.0
+	 * @access private
+	 * @return boolean User has saved credentials to DB.
+	 */
+	public function has_credentials() {
+		$credentials = $this->get_api_credentials();
+		return ! empty( $credentials['subdomain'] ) && ! empty( $credentials['username'] ) && ! empty( $credentials['password'] );
+	}
 }

--- a/includes/class-smaily-for-wp-option-handler.php
+++ b/includes/class-smaily-for-wp-option-handler.php
@@ -71,8 +71,10 @@ class Smaily_For_WP_Option_Handler {
 	 * @access private
 	 * @return boolean User has saved credentials to DB.
 	 */
-	public function has_credentials() {
-		$credentials = $this->get_api_credentials();
+	public function has_credentials( $credentials = null ) {
+		if ( ! isset( $credentials ) ) {
+			$credentials = $this->get_api_credentials();
+		}
 		return ! empty( $credentials['subdomain'] ) && ! empty( $credentials['username'] ) && ! empty( $credentials['password'] );
 	}
 }

--- a/includes/class-smaily-for-wp-options.php
+++ b/includes/class-smaily-for-wp-options.php
@@ -6,7 +6,7 @@
  * @package    Smaily_For_WP
  * @subpackage Smaily_For_WP/includes
  */
-class Smaily_For_WP_Option_Handler {
+class Smaily_For_WP_Options {
 
 	/**
 	 * Get API credentials stored in database.

--- a/includes/class-smaily-for-wp-options.php
+++ b/includes/class-smaily-for-wp-options.php
@@ -102,7 +102,7 @@ class Smaily_For_WP_Options {
 		if ( is_array( $api_credentials ) ) {
 			$this->api_credentials = array_map( 'sanitize_text_field', $api_credentials );
 		}
-		update_option( 'smailyforwp_api_option', $api_credentials, false );
+		update_option( 'smailyforwp_api_option', $this->api_credentials, false );
 	}
 
 	/**
@@ -116,7 +116,7 @@ class Smaily_For_WP_Options {
 		if ( is_array( $form_options ) ) {
 			$this->form_options = array_map( 'sanitize_text_field', $form_options );
 		}
-		update_option( 'smailyforwp_form_option', $form_options );
+		update_option( 'smailyforwp_form_option', $this->form_options );
 	}
 
 	/**

--- a/includes/class-smaily-for-wp-options.php
+++ b/includes/class-smaily-for-wp-options.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * This class is used to work with options related to user input e.g API credentials, form settings.
+ * This class is used to work with the plugin's options
+ * that take user input e.g API credentials, form settings.
  *
  * @since      3.0.0
  * @package    Smaily_For_WP
@@ -9,12 +10,57 @@
 class Smaily_For_WP_Options {
 
 	/**
+	 * Smaily API credentials
+	 *
+	 * @since  3.0.0
+	 * @access private
+	 * @var    array   $api_credentials Smaily API credentials.
+	 */
+	private $api_credentials;
+
+	/**
+	 * Newsletter signup form settings.
+	 *
+	 * @since  3.0.0
+	 * @access private
+	 * @var    array   $form_options Newsletter signup form settings.
+	 */
+	private $form_options;
+
+	/**
+	 * Get API credentials.
+	 *
+	 * @since  3.0.0
+	 * @return array   $api_credentials Smaily API credentials
+	 */
+	public function get_api_credentials() {
+		if ( is_null( $this->api_credentials ) ) {
+			$this->api_credentials = $this->get_api_credentials_from_db();
+		}
+		return $this->api_credentials;
+	}
+
+	/**
+	 * Get form options.
+	 *
+	 * @since  3.0.0
+	 * @return array   $form_options Newsletter signup form settings.
+	 */
+	public function get_form_options() {
+		if ( is_null( $this->form_options ) ) {
+			$this->form_options = $this->get_form_options_from_db();
+		}
+		return $this->form_options;
+	}
+
+	/**
 	 * Get API credentials stored in database.
 	 *
 	 * @since  3.0.0
-	 * @return array API credentials in proper format.
+	 * @access private
+	 * @return array   API credentials in proper format.
 	 */
-	public function get_api_credentials() {
+	private function get_api_credentials_from_db() {
 		$credentials = get_option( 'smailyforwp_api_option', array() );
 		return array_merge(
 			array(
@@ -30,9 +76,10 @@ class Smaily_For_WP_Options {
 	 * Get form options stored in database.
 	 *
 	 * @since  3.0.0
-	 * @return array Form options in proper format
+	 * @access private
+	 * @return array   Form options in proper format
 	 */
-	public function get_form_options() {
+	private function get_form_options_from_db() {
 		$form_options = get_option( 'smailyforwp_form_option', array() );
 		return array_merge(
 			array(
@@ -51,6 +98,11 @@ class Smaily_For_WP_Options {
 	 * @param array $api_credentials Smaily API credentials.
 	 */
 	public function update_api_credentials( $api_credentials ) {
+		// Update_option will sanitize input, before saving. We should sanitize aswell.
+		if ( is_array( $api_credentials ) ) {
+			$this->api_credentials = array_map( 'sanitize_text_field', $api_credentials );
+		}
+		$this->api_credentials = $api_credentials;
 		update_option( 'smailyforwp_api_option', $api_credentials, false );
 	}
 
@@ -61,6 +113,10 @@ class Smaily_For_WP_Options {
 	 * @param array $form_options Newsletter form options.
 	 */
 	public function update_form_options( $form_options ) {
+		// Update_option will sanitize input, before saving. We should sanitize aswell.
+		if ( is_array( $form_options ) ) {
+			$this->form_options = array_map( 'sanitize_text_field', $form_options );
+		}
 		update_option( 'smailyforwp_form_option', $form_options );
 	}
 
@@ -70,6 +126,7 @@ class Smaily_For_WP_Options {
 	 * @since 3.0.0
 	 */
 	public function remove_api_credentials() {
+		$this->api_credentials = null;
 		delete_option( 'smailyforwp_api_option' );
 	}
 
@@ -78,21 +135,19 @@ class Smaily_For_WP_Options {
 	 *
 	 * @since 3.0.0
 	 */
-	public function remove_form_credentials() {
+	public function remove_form_options() {
+		$this->form_options = null;
 		delete_option( 'smailyforwp_form_option' );
 	}
 
 	/**
-	 * Has user saved valid Smaily API credentials to database?
+	 * Has user saved Smaily API credentials to database?
 	 *
 	 * @since  3.0.0
-	 * @param  array $credentials Smaily API credentials.
-	 * @return boolean User has saved credentials to DB.
+	 * @return boolean True if API option exists, false if it doesn't exist.
 	 */
-	public function has_credentials( $credentials = null ) {
-		if ( ! isset( $credentials ) ) {
-			$credentials = $this->get_api_credentials();
-		}
-		return ! empty( $credentials['subdomain'] ) && ! empty( $credentials['username'] ) && ! empty( $credentials['password'] );
+	public function has_credentials() {
+		$api_credentials = $this->get_api_credentials();
+		return ! empty( $api_credentials['subdomain'] ) && ! empty( $api_credentials['username'] ) && ! empty( $api_credentials['password'] );
 	}
 }

--- a/includes/class-smaily-for-wp-options.php
+++ b/includes/class-smaily-for-wp-options.php
@@ -98,7 +98,7 @@ class Smaily_For_WP_Options {
 	 * @param array $api_credentials Smaily API credentials.
 	 */
 	public function update_api_credentials( $api_credentials ) {
-		// Update_option will sanitize input, before saving. We should sanitize aswell.
+		// Update_option will sanitize input before saving. We should sanitize aswell.
 		if ( is_array( $api_credentials ) ) {
 			$this->api_credentials = array_map( 'sanitize_text_field', $api_credentials );
 		}
@@ -113,7 +113,7 @@ class Smaily_For_WP_Options {
 	 * @param array $form_options Newsletter form options.
 	 */
 	public function update_form_options( $form_options ) {
-		// Update_option will sanitize input, before saving. We should sanitize aswell.
+		// Update_option will sanitize input before saving. We should sanitize aswell.
 		if ( is_array( $form_options ) ) {
 			$this->form_options = array_map( 'sanitize_text_field', $form_options );
 		}

--- a/includes/class-smaily-for-wp-options.php
+++ b/includes/class-smaily-for-wp-options.php
@@ -98,7 +98,7 @@ class Smaily_For_WP_Options {
 	 * @param array $api_credentials Smaily API credentials.
 	 */
 	public function update_api_credentials( $api_credentials ) {
-		// Update_option will sanitize input before saving. We should sanitize aswell.
+		// Update_option will sanitize input before saving. We should sanitize as well.
 		if ( is_array( $api_credentials ) ) {
 			$this->api_credentials = array_map( 'sanitize_text_field', $api_credentials );
 		}
@@ -112,7 +112,7 @@ class Smaily_For_WP_Options {
 	 * @param array $form_options Newsletter form options.
 	 */
 	public function update_form_options( $form_options ) {
-		// Update_option will sanitize input before saving. We should sanitize aswell.
+		// Update_option will sanitize input before saving. We should sanitize as well.
 		if ( is_array( $form_options ) ) {
 			$this->form_options = array_map( 'sanitize_text_field', $form_options );
 		}

--- a/includes/class-smaily-for-wp-options.php
+++ b/includes/class-smaily-for-wp-options.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Define the plugin's reading and writing functionality, from and to WordPress' options table.
+ * This class is used to work with options related to user input e.g API credentials, form settings.
  *
  * @since      3.0.0
  * @package    Smaily_For_WP

--- a/includes/class-smaily-for-wp-options.php
+++ b/includes/class-smaily-for-wp-options.php
@@ -68,7 +68,6 @@ class Smaily_For_WP_Options {
 	 * Has user saved valid Smaily API credentials to database.
 	 *
 	 * @since  3.0.0
-	 * @access private
 	 * @param  array $credentials Smaily API credentials.
 	 * @return boolean User has saved credentials to DB.
 	 */

--- a/includes/class-smaily-for-wp-options.php
+++ b/includes/class-smaily-for-wp-options.php
@@ -144,7 +144,7 @@ class Smaily_For_WP_Options {
 	 * Has user saved Smaily API credentials to database?
 	 *
 	 * @since  3.0.0
-	 * @return boolean True if API option exists, false if it doesn't exist.
+	 * @return boolean True if $api_credentials has correct key structure and no empty values.
 	 */
 	public function has_credentials() {
 		$api_credentials = $this->get_api_credentials();

--- a/includes/class-smaily-for-wp-options.php
+++ b/includes/class-smaily-for-wp-options.php
@@ -65,7 +65,25 @@ class Smaily_For_WP_Options {
 	}
 
 	/**
-	 * Has user saved valid Smaily API credentials to database.
+	 * Clear Smaily API credentials by deleting its option.
+	 *
+	 * @since 3.0.0
+	 */
+	public function remove_api_credentials() {
+		delete_option( 'smailyforwp_api_option' );
+	}
+
+	/**
+	 * Clear configurations for newsletter subscription from by deleting its option.
+	 *
+	 * @since 3.0.0
+	 */
+	public function remove_form_credentials() {
+		delete_option( 'smailyforwp_form_option' );
+	}
+
+	/**
+	 * Has user saved valid Smaily API credentials to database?
 	 *
 	 * @since  3.0.0
 	 * @param  array $credentials Smaily API credentials.

--- a/includes/class-smaily-for-wp-options.php
+++ b/includes/class-smaily-for-wp-options.php
@@ -102,7 +102,6 @@ class Smaily_For_WP_Options {
 		if ( is_array( $api_credentials ) ) {
 			$this->api_credentials = array_map( 'sanitize_text_field', $api_credentials );
 		}
-		$this->api_credentials = $api_credentials;
 		update_option( 'smailyforwp_api_option', $api_credentials, false );
 	}
 

--- a/includes/class-smaily-for-wp-widget.php
+++ b/includes/class-smaily-for-wp-widget.php
@@ -37,7 +37,7 @@ class Smaily_For_WP_Widget extends WP_Widget {
 		parent::__construct( 'smaily_subscription_widget', __( 'Smaily Newsletter Subscription', 'smaily-for-wp' ), $widget_ops );
 
 		$this->autoresponders = $admin_model->get_autoresponders();
-		$this->option_handler = new Smaily_For_WP_Options();
+		$this->options = new Smaily_For_WP_Options();
 	}
 
 	/**
@@ -62,8 +62,8 @@ class Smaily_For_WP_Widget extends WP_Widget {
 		}
 
 		// Load configuration data.
-		$api_credentials = $this->option_handler->get_api_credentials();
-		$form_options    = $this->option_handler->get_form_options();
+		$api_credentials = $this->options->get_api_credentials();
+		$form_options    = $this->options->get_form_options();
 		// Data to be assigned to template.
 		$config                     = array();
 		$config['domain']           = $api_credentials['subdomain'];
@@ -83,7 +83,7 @@ class Smaily_For_WP_Widget extends WP_Widget {
 		$form_is_successful = false;
 		$response_message   = null;
 
-		if ( ! $this->option_handler->has_credentials( $api_credentials ) ) {
+		if ( ! $this->options->has_credentials( $api_credentials ) ) {
 			$form_has_response = true;
 			$response_message  = __( 'Smaily credentials not validated. Subscription form will not work!', 'smaily-for-wp' );
 		} elseif ( isset( $_GET['code'] ) && (int) $_GET['code'] === 101 ) {

--- a/includes/class-smaily-for-wp-widget.php
+++ b/includes/class-smaily-for-wp-widget.php
@@ -66,16 +66,16 @@ class Smaily_For_WP_Widget extends WP_Widget {
 		$form_options    = $this->option_handler->get_form_options();
 		// Data to be assigned to template.
 		$config                     = array();
-		$config['domain']           = isset( $api_credentials['subdomain'] ) ? $api_credentials['subdomain'] : '';
-		$config['form']             = isset( $form_options['form'] ) ? $form_options['form'] : '';
-		$config['is_advanced']      = isset( $form_options['is_advanced'] ) ? $form_options['is_advanced'] : '';
+		$config['domain']           = $api_credentials['subdomain'];
+		$config['form']             = $form_options['form'];
+		$config['is_advanced']      = $form_options['is_advanced'];
 		$config['show_name']        = $show_name;
 		$config['success_url']      = $success_url;
 		$config['failure_url']      = $failure_url;
 		$config['autoresponder_id'] = $autoresponder;
 
 		// Create admin template.
-		$file     = ( isset( $config['is_advanced'] ) && '1' === $config['is_advanced'] ) ? 'advanced.php' : 'basic.php';
+		$file     = $config['is_advanced'] === '1' ? 'advanced.php' : 'basic.php';
 		$template = new Smaily_For_WP_Template( 'public/partials/smaily-for-wp-public-' . $file );
 		$template->assign( $config );
 		// Display responses on Smaily subscription form.

--- a/includes/class-smaily-for-wp-widget.php
+++ b/includes/class-smaily-for-wp-widget.php
@@ -22,9 +22,9 @@ class Smaily_For_WP_Widget extends WP_Widget {
 	 *
 	 * @since  3.0.0
 	 * @access private
-	 * @var    Smaily_For_WP_Option_Handler $option_handler Handler for Options API.
+	 * @var    Smaily_For_WP_Options $options Handler for Options API.
 	 */
-	private $option_handler;
+	private $options;
 
 	/**
 	 * Sets up a new instance of the widget.
@@ -37,7 +37,7 @@ class Smaily_For_WP_Widget extends WP_Widget {
 		parent::__construct( 'smaily_subscription_widget', __( 'Smaily Newsletter Subscription', 'smaily-for-wp' ), $widget_ops );
 
 		$this->autoresponders = $admin_model->get_autoresponders();
-		$this->option_handler = new Smaily_For_WP_Option_Handler();
+		$this->option_handler = new Smaily_For_WP_Options();
 	}
 
 	/**

--- a/includes/class-smaily-for-wp-widget.php
+++ b/includes/class-smaily-for-wp-widget.php
@@ -83,8 +83,7 @@ class Smaily_For_WP_Widget extends WP_Widget {
 		$form_is_successful = false;
 		$response_message   = null;
 
-		$credentials_not_valid = empty( $api_credentials['subdomain'] ) || empty( $api_credentials['username'] ) || empty( $api_credentials['password'] );
-		if ( $credentials_not_valid ) {
+		if ( ! $this->option_handler->has_credentials( $api_credentials ) ) {
 			$form_has_response = true;
 			$response_message  = __( 'Smaily credentials not validated. Subscription form will not work!', 'smaily-for-wp' );
 		} elseif ( isset( $_GET['code'] ) && (int) $_GET['code'] === 101 ) {

--- a/includes/class-smaily-for-wp-widget.php
+++ b/includes/class-smaily-for-wp-widget.php
@@ -84,7 +84,7 @@ class Smaily_For_WP_Widget extends WP_Widget {
 		$form_is_successful = false;
 		$response_message   = null;
 
-		if ( ! $this->options->has_credentials( $api_credentials ) ) {
+		if ( ! $this->options->has_credentials() ) {
 			$form_has_response = true;
 			$response_message  = __( 'Smaily credentials not validated. Subscription form will not work!', 'smaily-for-wp' );
 		} elseif ( isset( $_GET['code'] ) && (int) $_GET['code'] === 101 ) {

--- a/includes/class-smaily-for-wp-widget.php
+++ b/includes/class-smaily-for-wp-widget.php
@@ -30,14 +30,15 @@ class Smaily_For_WP_Widget extends WP_Widget {
 	 * Sets up a new instance of the widget.
 	 *
 	 * @since 3.0.0
-	 * @param Smaily_For_WP_Admin $admin_model Reference to admin class.
+	 * @param Smaily_For_WP_Options $options     Reference to options handler class.
+	 * @param Smaily_For_WP_Admin   $admin_model Reference to admin class.
 	 */
-	public function __construct( $admin_model ) {
+	public function __construct( Smaily_For_WP_Options $options, Smaily_For_WP_Admin $admin_model ) {
 		$widget_ops = array( 'description' => __( 'Smaily newsletter subscription form', 'smaily-for-wp' ) );
 		parent::__construct( 'smaily_subscription_widget', __( 'Smaily Newsletter Subscription', 'smaily-for-wp' ), $widget_ops );
 
+		$this->options        = $options;
 		$this->autoresponders = $admin_model->get_autoresponders();
-		$this->options = new Smaily_For_WP_Options();
 	}
 
 	/**

--- a/includes/class-smaily-for-wp-widget.php
+++ b/includes/class-smaily-for-wp-widget.php
@@ -18,6 +18,15 @@ class Smaily_For_WP_Widget extends WP_Widget {
 	private $autoresponders;
 
 	/**
+	 * Handler for storing/retrieving data via Options API.
+	 *
+	 * @since  3.0.0
+	 * @access private
+	 * @var    Smaily_For_WP_Option_Handler $option_handler Handler for Options API.
+	 */
+	private $option_handler;
+
+	/**
 	 * Sets up a new instance of the widget.
 	 *
 	 * @since 3.0.0
@@ -28,6 +37,7 @@ class Smaily_For_WP_Widget extends WP_Widget {
 		parent::__construct( 'smaily_subscription_widget', __( 'Smaily Newsletter Subscription', 'smaily-for-wp' ), $widget_ops );
 
 		$this->autoresponders = $admin_model->get_autoresponders();
+		$this->option_handler = new Smaily_For_WP_Option_Handler();
 	}
 
 	/**
@@ -52,9 +62,13 @@ class Smaily_For_WP_Widget extends WP_Widget {
 		}
 
 		// Load configuration data.
-		$config                     = (array) get_option( 'smailyforwp_form_option' );
-		$api_credentials            = get_option( 'smailyforwp_api_option' );
+		$api_credentials = $this->option_handler->get_api_credentials();
+		$form_options    = $this->option_handler->get_form_options();
+		// Data to be assigned to template.
+		$config                     = array();
 		$config['domain']           = isset( $api_credentials['subdomain'] ) ? $api_credentials['subdomain'] : '';
+		$config['form']             = isset( $form_options['form'] ) ? $form_options['form'] : '';
+		$config['is_advanced']      = isset( $form_options['is_advanced'] ) ? $form_options['is_advanced'] : '';
 		$config['show_name']        = $show_name;
 		$config['success_url']      = $success_url;
 		$config['failure_url']      = $failure_url;

--- a/includes/class-smaily-for-wp.php
+++ b/includes/class-smaily-for-wp.php
@@ -15,6 +15,15 @@
 class Smaily_For_WP {
 
 	/**
+	 * Handler for storing/retrieving data via Options API.
+	 *
+	 * @since  3.0.0
+	 * @access protected
+	 * @var    Smaily_For_WP_Options Handler for WordPress Options API.
+	 */
+	protected $options;
+
+	/**
 	 * The loader that's responsible for maintaining and registering all hooks that power
 	 * the plugin.
 	 *
@@ -92,7 +101,8 @@ class Smaily_For_WP {
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-template.php';
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-widget.php';
 		require_once SMLY4WP_PLUGIN_PATH . 'public/class-smaily-for-wp-public.php';
-		$this->loader = new Smaily_For_WP_Loader();
+		$this->loader  = new Smaily_For_WP_Loader();
+		$this->options = new Smaily_For_WP_Options();
 	}
 
 	/**
@@ -134,7 +144,7 @@ class Smaily_For_WP {
 	 * @access private
 	 */
 	private function define_admin_hooks() {
-		$plugin_admin = new Smaily_For_WP_Admin( $this->get_plugin_name(), $this->get_version() );
+		$plugin_admin = new Smaily_For_WP_Admin( $this->options, $this->get_plugin_name(), $this->get_version() );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 		$this->loader->add_action( 'wp_ajax_smaily_admin_save', $plugin_admin, 'smaily_admin_save' );
@@ -150,7 +160,7 @@ class Smaily_For_WP {
 	 * @access private
 	 */
 	private function define_public_hooks() {
-		$plugin_public = new Smaily_For_WP_Public( $this->get_plugin_name(), $this->get_version() );
+		$plugin_public = new Smaily_For_WP_Public( $this->options, $this->get_plugin_name(), $this->get_version() );
 		$this->loader->add_action( 'init', $plugin_public, 'add_shortcodes' );
 	}
 

--- a/includes/class-smaily-for-wp.php
+++ b/includes/class-smaily-for-wp.php
@@ -87,7 +87,7 @@ class Smaily_For_WP {
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-i18n.php';
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-lifecycle.php';
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-loader.php';
-		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-option-handler.php';
+		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-options.php';
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-request.php';
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-template.php';
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-widget.php';

--- a/includes/class-smaily-for-wp.php
+++ b/includes/class-smaily-for-wp.php
@@ -70,6 +70,7 @@ class Smaily_For_WP {
 	 * - Smaily_For_WP_i18n.      Defines internationalization functionality.
 	 * - Smaily_For_WP_Lifecycle. Defines the install, upgrade and uninstall functionality.
 	 * - Smaily_For_WP_Loader.    Orchestrates the hooks of the plugin.
+	 * - Smaily_For_WP_Option.    Defines the database related queries of Options API.
 	 * - Smaily_For_WP_Request.   Defines the request making functionality.
 	 * - Smaily_For_WP_Template.  Defines the templating making functionality.
 	 * - Smaily_For_WP_Widget.    Defines the widget functionality.
@@ -86,6 +87,7 @@ class Smaily_For_WP {
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-i18n.php';
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-lifecycle.php';
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-loader.php';
+		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-option-handler.php';
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-request.php';
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-template.php';
 		require_once SMLY4WP_PLUGIN_PATH . 'includes/class-smaily-for-wp-widget.php';

--- a/migrations/upgrade-3_0_0.php
+++ b/migrations/upgrade-3_0_0.php
@@ -19,7 +19,7 @@ $upgrade = function() {
 		// Get saved autoresponder ID.
 		$autoresponder_id = isset( $config['autoresponder'] ) ? $config['autoresponder'] : '';
 		// Get widgets' options.
-		$widget_options = get_option( 'widget_smaily_subscription_widget' );
+		$widget_options = get_option( 'widget_smaily_subscription_widget', array() );
 
 		foreach ( $widget_options as &$widget ) {
 			// Widgets created before 3.0.0 do not have autoresponder value, adding it here.

--- a/migrations/upgrade-3_0_0.php
+++ b/migrations/upgrade-3_0_0.php
@@ -2,8 +2,11 @@
 /**
  * Apply any database upgrades required for 3.0.0.
  *
- * Autoresponder configuration was moved from admin settings to widget settings.
- * All widgets must be updated with an autoresponder field.
+ * Autoresponder configuration was moved from admin settings to widget settings,
+ * all widgets must be updated with an autoresponder field.
+ *
+ * Plugin settings were previously stored in smaily_config table, they must be
+ * copied over to smailyforwp_api_option and smailyforwp_form_option.
  *
  * @since 3.0.0
  */
@@ -12,8 +15,9 @@ $upgrade = function() {
 	$table_name = $wpdb->prefix . 'smaily_config';
 
 	if ( $wpdb->get_var( "SHOW TABLES LIKE '$table_name'" ) === $table_name ) {
+		$config = $wpdb->get_row( "SELECT * FROM `$table_name` LIMIT 1", ARRAY_A );
 		// Get saved autoresponder ID.
-		$autoresponder_id = $wpdb->get_var( "SELECT autoresponder FROM `$table_name` LIMIT 1" );
+		$autoresponder_id = isset( $config['autoresponder'] ) ? $config['autoresponder'] : '';
 		// Get widgets' options.
 		$widget_options = get_option( 'widget_smaily_subscription_widget' );
 
@@ -24,6 +28,33 @@ $upgrade = function() {
 			}
 		}
 		update_option( 'widget_smaily_subscription_widget', $widget_options );
+
+		$api_options = array(
+			'subdomain' => ! empty( $config['domain'] ) ? $config['domain'] : '',
+			'username'  => '',
+			'password'  => '',
+		);
+
+		// In versions before 3.0.0, credentials were stored in format username:password.
+		$split_credentials = explode( ':', $config['api_credentials'] );
+		if ( count( $split_credentials ) === 2 ) {
+			$api_options['username'] = $split_credentials[0];
+			$api_options['password'] = $split_credentials[1];
+		}
+
+		// Disable autoloading API credentials, as they are are delicate.
+		update_option( 'smailyforwp_api_option', $api_options, false );
+
+		// Copy advanced form configurations from smaily_config table to form option.
+		$form_options = array(
+			'form'        => ! empty( $config['form'] ) ? $config['form'] : '',
+			'is_advanced' => isset( $config['is_advanced'] ) ? $config['is_advanced'] : '0',
+		);
+		update_option( 'smailyforwp_form_option', $form_options );
+
+		// All settings have been copied, delete old database table.
+		$wpdb->query( "DROP TABLE {$wpdb->prefix}smaily_config" );
+
 	}
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}smaily_autoresponders" );
 };

--- a/public/class-smaily-for-wp-public.php
+++ b/public/class-smaily-for-wp-public.php
@@ -45,7 +45,7 @@ class Smaily_For_WP_Public {
 	public function __construct( $plugin_name, $version ) {
 		$this->plugin_name    = $plugin_name;
 		$this->version        = $version;
-		$this->option_handler = new Smaily_For_WP_Options();
+		$this->options = new Smaily_For_WP_Options();
 	}
 
 	/**
@@ -65,8 +65,8 @@ class Smaily_For_WP_Public {
 	 */
 	public function smaily_shortcode_render( $atts ) {
 		// Load configuration data.
-		$api_credentials = $this->option_handler->get_api_credentials();
-		$form_options    = $this->option_handler->get_form_options();
+		$api_credentials = $this->options->get_api_credentials();
+		$form_options    = $this->options->get_form_options();
 		// Data to be assigned to template.
 		$config                = array();
 		$config['domain']      = $api_credentials['subdomain'];

--- a/public/class-smaily-for-wp-public.php
+++ b/public/class-smaily-for-wp-public.php
@@ -84,7 +84,8 @@ class Smaily_For_WP_Public {
 		$form_is_successful = false;
 		$response_message   = null;
 
-		if ( ! isset( $config['api_credentials'] ) || empty( $config['api_credentials'] ) ) {
+		$credentials_not_valid = empty( $api_credentials['subdomain'] ) || empty( $api_credentials['username'] ) || empty( $api_credentials['password'] );
+		if ( $credentials_not_valid ) {
 			$form_has_response = true;
 			$response_message  = __( 'Smaily credentials not validated. Subscription form will not work!', 'smaily-for-wp' );
 		} elseif ( isset( $_GET['code'] ) && (int) $_GET['code'] === 101 ) {

--- a/public/class-smaily-for-wp-public.php
+++ b/public/class-smaily-for-wp-public.php
@@ -27,6 +27,15 @@ class Smaily_For_WP_Public {
 	private $version;
 
 	/**
+	 * Handler for storing/retrieving data via Options API.
+	 *
+	 * @since  3.0.0
+	 * @access private
+	 * @var    Smaily_For_WP_Option_Handler $option_handler Handler for Options API.
+	 */
+	private $option_handler;
+
+	/**
 	 * Initialize the class and set its properties.
 	 *
 	 * @since 3.0.0
@@ -34,8 +43,9 @@ class Smaily_For_WP_Public {
 	 * @param string $version     The version of this plugin.
 	 */
 	public function __construct( $plugin_name, $version ) {
-		$this->plugin_name = $plugin_name;
-		$this->version = $version;
+		$this->plugin_name    = $plugin_name;
+		$this->version        = $version;
+		$this->option_handler = new Smaily_For_WP_Option_Handler();
 	}
 
 	/**
@@ -55,10 +65,13 @@ class Smaily_For_WP_Public {
 	 */
 	public function smaily_shortcode_render( $atts ) {
 		// Load configuration data.
-		$config = (array) get_option( 'smailyforwp_form_option' );
-
-		$api_credentials  = get_option( 'smailyforwp_api_option' );
-		$config['domain'] = isset( $api_credentials['subdomain'] ) ? $api_credentials['subdomain'] : '';
+		$api_credentials = $this->option_handler->get_api_credentials();
+		$form_options    = $this->option_handler->get_form_options();
+		// Data to be assigned to template.
+		$config                = array();
+		$config['domain']      = isset( $api_credentials['subdomain'] ) ? $api_credentials['subdomain'] : '';
+		$config['form']        = isset( $form_options['form'] ) ? $form_options['form'] : '';
+		$config['is_advanced'] = isset( $form_options['is_advanced'] ) ? $form_options['is_advanced'] : '';
 
 		// Parse attributes out of shortcode tag.
 		$shortcode_atts = shortcode_atts(

--- a/public/class-smaily-for-wp-public.php
+++ b/public/class-smaily-for-wp-public.php
@@ -54,11 +54,11 @@ class Smaily_For_WP_Public {
 	 * @return string
 	 */
 	public function smaily_shortcode_render( $atts ) {
-		global $wpdb;
-
 		// Load configuration data.
-		$table_name = esc_sql( $wpdb->prefix . 'smaily_config' );
-		$config = (array) $wpdb->get_row( "SELECT * FROM `$table_name` LIMIT 1" );
+		$config = (array) get_option( 'smailyforwp_form_option' );
+
+		$api_credentials  = get_option( 'smailyforwp_api_option' );
+		$config['domain'] = isset( $api_credentials['subdomain'] ) ? $api_credentials['subdomain'] : '';
 
 		// Parse attributes out of shortcode tag.
 		$shortcode_atts = shortcode_atts(

--- a/public/class-smaily-for-wp-public.php
+++ b/public/class-smaily-for-wp-public.php
@@ -69,9 +69,9 @@ class Smaily_For_WP_Public {
 		$form_options    = $this->option_handler->get_form_options();
 		// Data to be assigned to template.
 		$config                = array();
-		$config['domain']      = isset( $api_credentials['subdomain'] ) ? $api_credentials['subdomain'] : '';
-		$config['form']        = isset( $form_options['form'] ) ? $form_options['form'] : '';
-		$config['is_advanced'] = isset( $form_options['is_advanced'] ) ? $form_options['is_advanced'] : '';
+		$config['domain']      = $api_credentials['subdomain'];
+		$config['form']        = $form_options['form'];
+		$config['is_advanced'] = $form_options['is_advanced'];
 
 		// Parse attributes out of shortcode tag.
 		$shortcode_atts = shortcode_atts(
@@ -89,7 +89,7 @@ class Smaily_For_WP_Public {
 		$config['autoresponder_id'] = $shortcode_atts['autoresponder_id'];
 
 		// Create admin template.
-		$file     = ( isset( $config['is_advanced'] ) && '1' === $config['is_advanced'] ) ? 'advanced.php' : 'basic.php';
+		$file     = $config['is_advanced'] === '1' ? 'advanced.php' : 'basic.php';
 		$template = new Smaily_For_WP_Template( 'public/partials/smaily-for-wp-public-' . $file );
 		$template->assign( $config );
 		// Display responses on Smaily subscription form.

--- a/public/class-smaily-for-wp-public.php
+++ b/public/class-smaily-for-wp-public.php
@@ -31,9 +31,9 @@ class Smaily_For_WP_Public {
 	 *
 	 * @since  3.0.0
 	 * @access private
-	 * @var    Smaily_For_WP_Option_Handler $option_handler Handler for Options API.
+	 * @var    Smaily_For_WP_Options $options Handler for Options API.
 	 */
-	private $option_handler;
+	private $options;
 
 	/**
 	 * Initialize the class and set its properties.
@@ -45,7 +45,7 @@ class Smaily_For_WP_Public {
 	public function __construct( $plugin_name, $version ) {
 		$this->plugin_name    = $plugin_name;
 		$this->version        = $version;
-		$this->option_handler = new Smaily_For_WP_Option_Handler();
+		$this->option_handler = new Smaily_For_WP_Options();
 	}
 
 	/**

--- a/public/class-smaily-for-wp-public.php
+++ b/public/class-smaily-for-wp-public.php
@@ -39,13 +39,14 @@ class Smaily_For_WP_Public {
 	 * Initialize the class and set its properties.
 	 *
 	 * @since 3.0.0
-	 * @param string $plugin_name The name of the plugin.
-	 * @param string $version     The version of this plugin.
+	 * @param Smaily_For_WP_Options $options     Reference to options handler class.
+	 * @param string                $plugin_name The name of the plugin.
+	 * @param string                $version     The version of this plugin.
 	 */
-	public function __construct( $plugin_name, $version ) {
-		$this->plugin_name    = $plugin_name;
-		$this->version        = $version;
-		$this->options = new Smaily_For_WP_Options();
+	public function __construct( Smaily_For_WP_Options $options, $plugin_name, $version ) {
+		$this->options     = $options;
+		$this->plugin_name = $plugin_name;
+		$this->version     = $version;
 	}
 
 	/**


### PR DESCRIPTION
Made 2 options, smailyforwp_api_option and smailyforwp_form_option. The former is used for subdomain, username, and password. The latter is for storing basic/advanced tab use (is_advanced) and form contents.

Refactored the huge smaily_admin_save function into smaller functions. 

I moved the advanced form element out of indention, previously it was "`advanced[form]`". I didn't see the point of separating it, if there's a good reason I'll revert it to like it was. 
Added proper escaping for the form element with `esc_textarea`.

`$form_data['op'] = array('save', 'refreshAutoresp')` had been left in from previous PRs, removed the _refreshAutoresp_ operation.
