### PR TITLE
Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.0.1
+- Hardcoded development plugin name breaks production CSS and JS loading [[#99](https://github.com/sendsmaily/sendsmaily-wordpress-plugin/pull/99)]
+
 ### 3.0.0
 
 - Autoresponders can be now be configured in widget settings and per widget - [[#84](https://github.com/sendsmaily/sendsmaily-wordpress-plugin/pull/84)]

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -58,7 +58,7 @@ class Smaily_For_WP_Admin {
 		wp_register_style( $this->plugin_name, SMLY4WP_PLUGIN_URL . '/admin/css/smaily-for-wp-admin.css', array(), $this->version, 'all' );
 		// Only enqueue in module page.
 		$screen = get_current_screen();
-		if ( isset( $screen->base ) && $screen->base === 'toplevel_page_sendsmaily-wordpress-plugin' ) {
+		if ( isset( $screen->base ) && $screen->base === 'toplevel_page_' . $this->plugin_name ) {
 			wp_enqueue_style( $this->plugin_name );
 		}
 	}
@@ -72,9 +72,9 @@ class Smaily_For_WP_Admin {
 		wp_register_script( $this->plugin_name, SMLY4WP_PLUGIN_URL . '/admin/js/smaily-for-wp-admin.js', array( 'jquery' ), $this->version, false );
 		// Only enqueue in module page.
 		$screen = get_current_screen();
-		if ( isset( $screen->base ) && $screen->base === 'toplevel_page_sendsmaily-wordpress-plugin' ) {
+		if ( isset( $screen->base ) && $screen->base === 'toplevel_page_' . $this->plugin_name ) {
 			wp_enqueue_script( $this->plugin_name );
-			wp_localize_script( $this->plugin_name, $this->plugin_name, array( 'ajax_url' => admin_url( 'admin-ajax.php' ) ) );
+			wp_localize_script( $this->plugin_name, 'smaily_for_wp', array( 'ajax_url' => admin_url( 'admin-ajax.php' ) ) );
 		}
 	}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       WORDPRESS_DB_PASSWORD: smailydev1
     volumes:
       - wordpress:/var/www/html
-      - ./:/var/www/html/wp-content/plugins/sendsmaily-wordpress-plugin
+      - ./:/var/www/html/wp-content/plugins/smaily-for-wp
 
   db:
     image: mysql:5.7

--- a/includes/class-smaily-for-wp.php
+++ b/includes/class-smaily-for-wp.php
@@ -62,7 +62,7 @@ class Smaily_For_WP {
 	 */
 	public function __construct() {
 		$this->version = SMLY4WP_PLUGIN_VERSION;
-		$this->plugin_name = 'smaily_for_wp';
+		$this->plugin_name = 'smaily-for-wp';
 		$this->load_dependencies();
 		$this->set_locale();
 		$this->define_lifecycle_hooks();

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: sendsmaily, kaarel, tomabel, marispulk
 License: GPLv2 or later
 Requires PHP: 5.6
 Requires at least: 4.0
-Stable tag: 3.0.0
+Stable tag: 3.0.1
 Tags: widget, plugin, sidebar, api, mail, email, marketing, smaily
 Tested up to: 5.6.0
 
@@ -74,6 +74,9 @@ When no autoresponder selected regular opt-in workflow will run. You can add del
 5. Smaily plugin shortcode from.
 
 == Changelog ==
+
+= 3.0.1 =
+- Fix hardcoded development plugin name breaks production CSS and JS loading
 
 = 3.0.0 =
 - Autoresponders can be now be configured in widget settings and per widget.

--- a/smaily-for-wp.php
+++ b/smaily-for-wp.php
@@ -9,7 +9,7 @@
  * Plugin URI:        https://github.com/sendsmaily/sendsmaily-wordpress-plugin/
  * Text Domain:       smaily-for-wp
  * Description:       Smaily newsletter subscription form.
- * Version:           3.0.0
+ * Version:           3.0.1
  * Author:            Sendsmaily LLC
  * Author URI:        https://smaily.com
  * License:           GPL-2.0+
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Current plugin version.
  */
-define( 'SMLY4WP_PLUGIN_VERSION', '3.0.0' );
+define( 'SMLY4WP_PLUGIN_VERSION', '3.0.1' );
 
 /**
  * Absolute URL to the Smaily for WP plugin directory.


### PR DESCRIPTION
**Version changelog**

- Hardcoded development plugin name breaks production CSS and JS loading [[#99](https://github.com/sendsmaily/sendsmaily-wordpress-plugin/pull/99)]

**Release checklist**

- [x] Added `release` tag to this pull request
- [x] Updated README.md
- [x] Updated readme.txt
- [x] Updated CHANGELOG.md
- [x] Updated CONTRIBUTION.md
- [x] Updated plugin version number
- [x] Updated screenshots in assets folder
- [x] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Ran the `release.sh` script to publish plugin to WordPress plugin library
- [ ] Pinged code owners to inform marketing about new version
