### PR TITLE
Release 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
+### 3.0.2
+
+- Remove unnecessary static content limiting [[#102](https://github.com/sendsmaily/sendsmaily-wordpress-plugin/pull/102)]
+
 ### 3.0.1
+
 - Hardcoded development plugin name breaks production CSS and JS loading [[#99](https://github.com/sendsmaily/sendsmaily-wordpress-plugin/pull/99)]
 
 ### 3.0.0

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -56,11 +56,7 @@ class Smaily_For_WP_Admin {
 	 */
 	public function enqueue_styles() {
 		wp_register_style( $this->plugin_name, SMLY4WP_PLUGIN_URL . '/admin/css/smaily-for-wp-admin.css', array(), $this->version, 'all' );
-		// Only enqueue in module page.
-		$screen = get_current_screen();
-		if ( isset( $screen->base ) && $screen->base === 'toplevel_page_' . $this->plugin_name ) {
-			wp_enqueue_style( $this->plugin_name );
-		}
+		wp_enqueue_style( $this->plugin_name );
 	}
 
 	/**
@@ -70,12 +66,8 @@ class Smaily_For_WP_Admin {
 	 */
 	public function enqueue_scripts() {
 		wp_register_script( $this->plugin_name, SMLY4WP_PLUGIN_URL . '/admin/js/smaily-for-wp-admin.js', array( 'jquery' ), $this->version, false );
-		// Only enqueue in module page.
-		$screen = get_current_screen();
-		if ( isset( $screen->base ) && $screen->base === 'toplevel_page_' . $this->plugin_name ) {
-			wp_enqueue_script( $this->plugin_name );
-			wp_localize_script( $this->plugin_name, 'smaily_for_wp', array( 'ajax_url' => admin_url( 'admin-ajax.php' ) ) );
-		}
+		wp_enqueue_script( $this->plugin_name );
+		wp_localize_script( $this->plugin_name, 'smaily_for_wp', array( 'ajax_url' => admin_url( 'admin-ajax.php' ) ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: sendsmaily, kaarel, tomabel, marispulk
 License: GPLv2 or later
 Requires PHP: 5.6
 Requires at least: 4.0
-Stable tag: 3.0.1
+Stable tag: 3.0.2
 Tags: widget, plugin, sidebar, api, mail, email, marketing, smaily
 Tested up to: 5.6.0
 
@@ -74,6 +74,9 @@ When no autoresponder selected regular opt-in workflow will run. You can add del
 5. Smaily plugin shortcode from.
 
 == Changelog ==
+
+= 3.0.2 =
+- Remove unnecessary admin page static content filtering
 
 = 3.0.1 =
 - Fix hardcoded development plugin name breaks production CSS and JS loading

--- a/smaily-for-wp.php
+++ b/smaily-for-wp.php
@@ -9,7 +9,7 @@
  * Plugin URI:        https://github.com/sendsmaily/sendsmaily-wordpress-plugin/
  * Text Domain:       smaily-for-wp
  * Description:       Smaily newsletter subscription form.
- * Version:           3.0.1
+ * Version:           3.0.2
  * Author:            Sendsmaily LLC
  * Author URI:        https://smaily.com
  * License:           GPL-2.0+
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Current plugin version.
  */
-define( 'SMLY4WP_PLUGIN_VERSION', '3.0.1' );
+define( 'SMLY4WP_PLUGIN_VERSION', '3.0.2' );
 
 /**
  * Absolute URL to the Smaily for WP plugin directory.


### PR DESCRIPTION
**Version changelog**

- Remove unnecessary static content limiting [[#102](https://github.com/sendsmaily/sendsmaily-wordpress-plugin/pull/102)]

**Release checklist**

- [x] Added `release` tag to this pull request
- [x] Updated README.md
- [x] Updated readme.txt
- [x] Updated CHANGELOG.md
- [x] Updated CONTRIBUTION.md
- [x] Updated plugin version number
- [x] Updated screenshots in assets folder
- [x] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Ran the `release.sh` script to publish plugin to WordPress plugin library
- [ ] Pinged code owners to inform marketing about new version
