### PR TITLE
WordPress 5.7 compatibility tested

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires PHP: 5.6
 Requires at least: 4.0
 Stable tag: 3.0.2
 Tags: widget, plugin, sidebar, api, mail, email, marketing, smaily
-Tested up to: 5.6.0
+Tested up to: 5.7.0
 
 Smaily newsletter subscription plugin for WordPress
 


### PR DESCRIPTION
Tested WordPress 5.7 compatibility with Smaily for WordPress plugin.