### PR TITLE
fix: Fix an issue where administrator scripts are not loaded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.1.5
+
+- Fix an issue where administrator scripts are not loaded when DISALLOW_FILE_EDIT configuration option is enabled.
+
 ### 3.1.4
 
 - Fix a security issue where users who didn't have correct privileges to edit the plugin settings were allowed to do so through console in administrators interface. https://www.cve.org/CVERecord?id=CVE-2024-54286

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -63,10 +63,13 @@ class Smaily_For_WP_Admin {
 	 * Register the JavaScript for the admin area.
 	 *
 	 * @since 3.0.0
+	 * @since 3.1.4 Added a conditional check to load scripts only if user has 'edit_plugins' capability.
+	 * @since 3.1.5 Changed capability check to check administrator role instead of 'edit_plugins' capability.
 	 */
 	public function enqueue_scripts() {
 		$user = wp_get_current_user();
-		if ( $user->has_cap( 'edit_plugins' ) ) {
+		$allowed_roles = array( 'administrator' );
+		if ( array_intersect( $allowed_roles, $user->roles ) ) {
 			wp_register_script( $this->plugin_name, SMLY4WP_PLUGIN_URL . '/admin/js/smaily-for-wp-admin.js', array( 'jquery' ), $this->version, false );
 			wp_enqueue_script( $this->plugin_name );
 			wp_add_inline_script( $this->plugin_name, 'var smaily_for_wp = ' . json_encode( array( 'ajax_url' => admin_url( 'admin-ajax.php' ) ) ) . ';' );

--- a/admin/class-smaily-for-wp-admin.php
+++ b/admin/class-smaily-for-wp-admin.php
@@ -63,8 +63,6 @@ class Smaily_For_WP_Admin {
 	 * Register the JavaScript for the admin area.
 	 *
 	 * @since 3.0.0
-	 * @since 3.1.4 Added a conditional check to load scripts only if user has 'edit_plugins' capability.
-	 * @since 3.1.5 Changed capability check to check administrator role instead of 'edit_plugins' capability.
 	 */
 	public function enqueue_scripts() {
 		$user = wp_get_current_user();
@@ -146,7 +144,8 @@ class Smaily_For_WP_Admin {
 	 */
 	public function smaily_admin_save() {
 		$user = wp_get_current_user();
-		if ( ! $user->has_cap( 'edit_plugins' ) ) {
+		$allowed_roles = array( 'administrator' );
+		if ( !array_intersect( $allowed_roles, $user->roles ) ) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: sendsmaily, kaarel, tomabel, marispulk
 License: GPLv2 or later
 Requires PHP: 5.6
 Requires at least: 4.0
-Stable tag: 3.1.4
+Stable tag: 3.1.5
 Tags: widget, plugin, sidebar, api, mail, email, marketing, smaily
 Tested up to: 6.4
 
@@ -75,6 +75,9 @@ When no autoresponder selected regular opt-in workflow will run. You can add del
 6. Smaily plugin shortcode from.
 
 == Changelog ==
+
+= 3.1.5 =
+- Fix an issue where administrator scripts are not loaded when DISALLOW_FILE_EDIT configuration option is enabled.
 
 = 3.1.4 =
 - Fix a security issue where users who didn't have correct privileges to edit the plugin settings were allowed to do so through console in administrators interface. https://www.cve.org/CVERecord?id=CVE-2024-54286

--- a/smaily-for-wp.php
+++ b/smaily-for-wp.php
@@ -9,7 +9,7 @@
  * Plugin URI:        https://github.com/sendsmaily/sendsmaily-wordpress-plugin/
  * Text Domain:       smaily-for-wp
  * Description:       Smaily newsletter subscription form.
- * Version:           3.1.4
+ * Version:           3.1.5
  * Author:            Sendsmaily LLC
  * Author URI:        https://smaily.com
  * License:           GPL-2.0+
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Current plugin version.
  */
-define( 'SMLY4WP_PLUGIN_VERSION', '3.1.4' );
+define( 'SMLY4WP_PLUGIN_VERSION', '3.1.5' );
 
 /**
  * Absolute URL to the Smaily for WP plugin directory.


### PR DESCRIPTION
# Plugin Version:  3.1.5

**Version changelog**

Fix an issue where administrator scripts are not loaded when the `DISALLOW_FILE_EDIT` configuration option is enabled.

Veebimajutus WordPress installations by default enable the DISALLOW_FILE_EDIT configuration option. This causes issues for these clients. This advanced configuration option is documented also [here](https://developer.wordpress.org/advanced-administration/wordpress/wp-config/#disable-the-plugin-and-theme-file-editor) where plugin authors should check the configuration option.

I have now redesigned the module to use `administrator` role instead of the `edit_plugins` capability for loading scripts only to administrator users. This should be less error-prone across different configurations.

**Release checklist**

- [x] Added `release` tag to this pull request
- [ ] Updated README.md
- [x] Updated readme.txt
- [x] Updated CHANGELOG.md
- [ ] Updated CONTRIBUTION.md
- [x] Updated plugin version number
- [ ] Ensure schema and data migrations are created
- [ ] Updated screenshots in assets folder
- [ ] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Ran the `release.sh` script to publish plugin to WordPress plugin library
- [ ] Pinged code owners to inform marketing about new version
