### PR TITLE
form: Escape basic form display values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.1.6
+
+- Improve module security by escaping all of the basic newsletter form display fields.
+
 ### 3.1.5
 
 - Fix an issue where administrator scripts are not loaded when DISALLOW_FILE_EDIT configuration option is enabled.

--- a/public/partials/smaily-for-wp-public-basic.php
+++ b/public/partials/smaily-for-wp-public-basic.php
@@ -1,12 +1,12 @@
-<form id="smly" action="https://<?php echo $this->domain; ?>.sendsmaily.net/api/opt-in/" method="post">
+<form id="smly" action="https://<?php echo esc_attr( $this->domain ); ?>.sendsmaily.net/api/opt-in/" method="post">
 	<p class="error" style="padding:15px;background-color:#f2dede;margin:0 0 10px;display:<?php echo $this->form_has_response ? 'block' : 'none'; ?>"><?php echo esc_html( $this->response_message ); ?></p>
 	<p class="success" style="padding:15px;background-color:#dff0d8;margin:0 0 10px;display:<?php echo $this->form_is_successful ? 'block' : 'none'; ?>"><?php echo esc_html__( 'Thank you for subscribing to our newsletter.', 'smaily-for-wp' ); ?></p>
 	<?php if ( $this->autoresponder_id ) : ?>
-		<input type="hidden" name="autoresponder" value="<?php echo $this->autoresponder_id; ?>" />
+		<input type="hidden" name="autoresponder" value="<?php echo esc_attr( $this->autoresponder_id ); ?>" />
 	<?php endif; ?>
 	<input type="hidden" name="lang" value="<?php echo esc_html( $this->get_language_code() ); ?>" />
-	<input type="hidden" name="success_url" value="<?php echo $this->success_url ? $this->success_url : get_site_url(); ?>" />
-	<input type="hidden" name="failure_url" value="<?php echo $this->failure_url ? $this->failure_url : get_site_url(); ?>" />
+	<input type="hidden" name="success_url" value="<?php echo $this->success_url ? esc_attr( $this->success_url ) : get_site_url(); ?>" />
+	<input type="hidden" name="failure_url" value="<?php echo $this->failure_url ? esc_attr( $this->failure_url ) : get_site_url(); ?>" />
 	<p><input type="text" name="email" value="" placeholder="<?php echo esc_html__( 'Email', 'smaily-for-wp' ); ?>" required/></p>
 	<?php if ( $this->show_name ) : ?>
 		<p><input type="text" name="name" value="" placeholder="<?php echo esc_html__( 'Name', 'smaily-for-wp' ); ?>" /></p>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: sendsmaily, kaarel, tomabel, marispulk
 License: GPLv2 or later
 Requires PHP: 5.6
 Requires at least: 4.0
-Stable tag: 3.1.5
+Stable tag: 3.1.6
 Tags: widget, plugin, sidebar, api, mail, email, marketing, smaily
 Tested up to: 6.4
 
@@ -75,6 +75,9 @@ When no autoresponder selected regular opt-in workflow will run. You can add del
 6. Smaily plugin shortcode from.
 
 == Changelog ==
+
+= 3.1.6 =
+- Improve module security by escaping all of the basic newsletter form display fields.
 
 = 3.1.5 =
 - Fix an issue where administrator scripts are not loaded when DISALLOW_FILE_EDIT configuration option is enabled.

--- a/smaily-for-wp.php
+++ b/smaily-for-wp.php
@@ -9,7 +9,7 @@
  * Plugin URI:        https://github.com/sendsmaily/sendsmaily-wordpress-plugin/
  * Text Domain:       smaily-for-wp
  * Description:       Smaily newsletter subscription form.
- * Version:           3.1.5
+ * Version:           3.1.6
  * Author:            Sendsmaily LLC
  * Author URI:        https://smaily.com
  * License:           GPL-2.0+
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Current plugin version.
  */
-define( 'SMLY4WP_PLUGIN_VERSION', '3.1.5' );
+define( 'SMLY4WP_PLUGIN_VERSION', '3.1.6' );
 
 /**
  * Absolute URL to the Smaily for WP plugin directory.


### PR DESCRIPTION
# Plugin Version: 3.1.6

**Version changelog**

- Escapes correctly basic form values improving module security.

**Release checklist**

- [ ] Added `release` tag to this pull request
- [ ] Updated README.md
- [ ] Updated readme.txt
- [ ] Updated CHANGELOG.md
- [ ] Updated CONTRIBUTION.md
- [ ] Updated plugin version number
- [ ] Ensure schema and data migrations are created
- [ ] Updated screenshots in assets folder
- [ ] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Ran the `release.sh` script to publish plugin to WordPress plugin library
- [ ] Pinged code owners to inform marketing about new version
